### PR TITLE
Change default tag from latest to current

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest"
+          automatic_release_tag: "current"
           prerelease: false
           title: "Development Build [TODO: Replace label and number with version number]"
           files: |


### PR DESCRIPTION
Based on this: https://github.com/readthedocs/readthedocs.org/issues/4868, seems like "latest" tag is confusing readthedocs.