### PR TITLE
Setup workflow to publish to PyPI

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,32 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
@dave-doty Can you add the necessary secrets named `PYPI_USERNAME` and `PYPI_PASSWORD` to the [repositories' secrets](https://github.com/UC-Davis-molecular-computing/scadnano-python-package/settings/secrets). I tried this out with my [local fork secrets](https://github.com/UnHumbleBen/scadnano-python-package-1/settings/secrets) and it seems pretty safe in the sense that there is no way you can see the value of the secret that you entered. Even if you try to update them, Github will not show what was the previous value of the secret.