### PR TITLE
Adds PR to CI workflow

### DIFF
--- a/.github/workflows/check_pypi_packaging.yml
+++ b/.github/workflows/check_pypi_packaging.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - "master"
+  pull_request:
 
 jobs:
   check_pypi_packaging:

--- a/.github/workflows/check_pypi_packaging.yml
+++ b/.github/workflows/check_pypi_packaging.yml
@@ -1,9 +1,6 @@
 name: "Check PyPI Packaging"
 
 on:
-  push:
-    branches-ignore:
-      - "master"
   pull_request:
 
 jobs:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,5 +1,5 @@
 name: "Docs Check"
-on: push
+on: [push, pull_request]
 
 jobs:
   docs:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,5 +1,5 @@
 name: "Docs Check"
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   docs:

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -1,6 +1,6 @@
 name: Run Unit Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -1,6 +1,6 @@
 name: Run Unit Tests
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   build:


### PR DESCRIPTION
This fixes issue where PR from external forks would not have
CI checks, as in [this PR](https://github.com/UC-Davis-molecular-computing/scadnano-python-package/pull/142).

This commit fixes this issue, as shown in this
[sample PR](https://github.com/UnHumbleBen/scadnano-python-package-1/pull/5).
You can see that CI tests run now.