### PR TITLE
Fixes #163; Remove Helix.pitch and Helix.yaw

### DIFF
--- a/examples/1_staple_1_helix_origami_position_nondefault.py
+++ b/examples/1_staple_1_helix_origami_position_nondefault.py
@@ -3,14 +3,16 @@ import scadnano as sc
 
 def create_design() -> sc.Design:
     length = 9
+    pitch90_group = sc.HelixGroup(pitch=90)
     helices = [
-        sc.Helix(max_offset=length, major_ticks=[2, 5], position=sc.Position3D(x=1, y=2, z=3), pitch=90)]
+        sc.Helix(max_offset=length, major_ticks=[2, 5], position=sc.Position3D(x=1, y=2, z=3), group='pitch90')]
     stap_ss = sc.Domain(0, True, 0, length)
     scaf_ss = sc.Domain(0, False, 0, length)
     stap = sc.Strand([stap_ss])
     scaf = sc.Strand([scaf_ss], color=sc.default_scaffold_color)
     strands = [stap, scaf]
-    design = sc.Design(helices=helices, strands=strands, grid=sc.Grid.none)
+    design = sc.Design(helices=helices, groups={
+                       'pitch90': pitch90_group}, strands=strands)
     design.assign_dna(scaf, 'AACT' * (length // 4))
 
     return design

--- a/examples/4_helix_grid_none.py
+++ b/examples/4_helix_grid_none.py
@@ -4,10 +4,10 @@ import scadnano as sc
 def create_design() -> sc.Design:
     length = 10
     helices = [
-        sc.Helix(max_offset=length, position=sc.Position3D(x=0, y=0, z=2.5), pitch=0, roll=0, yaw=0),
-        sc.Helix(max_offset=length, position=sc.Position3D(x=3, y=3, z=0), pitch=0, roll=0, yaw=0),
-        sc.Helix(max_offset=length, position=sc.Position3D(x=8, y=-3, z=0), pitch=0, roll=0, yaw=0),
-        sc.Helix(max_offset=length, position=sc.Position3D(x=11, y=1, z=0), pitch=0, roll=0, yaw=0),
+        sc.Helix(max_offset=length, position=sc.Position3D(x=0, y=0, z=2.5), roll=0),
+        sc.Helix(max_offset=length, position=sc.Position3D(x=3, y=3, z=0), roll=0),
+        sc.Helix(max_offset=length, position=sc.Position3D(x=8, y=-3, z=0), roll=0),
+        sc.Helix(max_offset=length, position=sc.Position3D(x=11, y=1, z=0), roll=0),
     ]
     stap_ss = sc.Domain(0, True, 0, length)
     scaf_ss = sc.Domain(0, False, 0, length)

--- a/examples/output_designs/1_staple_1_helix_origami_position_nondefault.sc
+++ b/examples/output_designs/1_staple_1_helix_origami_position_nondefault.sc
@@ -1,10 +1,16 @@
 {
-  "version": "0.15.0",
-  "grid": "none",
+  "version": "0.16.0",
+  "groups": {
+    "pitch90": {
+      "position": {"x": 0, "y": 0, "z": 0},
+      "pitch": 90,
+      "grid": "none"
+    }
+  },
   "helices": [
     {
+      "group": "pitch90",
       "position": {"x": 1, "y": 2, "z": 3},
-      "pitch": 90,
       "major_ticks": [2, 5]
     }
   ],

--- a/tests/scadnano_tests.py
+++ b/tests/scadnano_tests.py
@@ -2754,8 +2754,29 @@ class TestSetHelixIdx(unittest.TestCase):
         self.assertEqual(8, ss5.end)
 
 
-class TestHelixGroups(unittest.TestCase):
+class TestDesignPitchYawRollOfHelix(unittest.TestCase):
+    def setUp(self) -> None:
+        n = 'north'
+        helix = sc.Helix(max_offset=12, group=n, grid_position=(1,2), roll=4)
 
+        group_north = sc.HelixGroup(position=sc.Position3D(x=0, y=-200, z=0), grid=sc.square, pitch=12, yaw=40, roll=32)
+        self.design = sc.Design(helices=[helix], groups={n: group_north}, strands=[])
+        self.helix = helix
+
+
+    def test_design_pitch_of_helix(self) -> None:
+        self.assertEqual(12,  self.design.pitch_of_helix(self.helix))
+
+
+    def test_design_yaw_of_helix(self) -> None:
+        self.assertEqual(40,  self.design.yaw_of_helix(self.helix))
+
+
+    def test_design_roll_of_helix(self) -> None:
+        self.assertEqual(36,  self.design.roll_of_helix(self.helix))
+
+
+class TestHelixGroups(unittest.TestCase):
     def setUp(self) -> None:
         n = 'north'
         e = 'east'
@@ -2872,6 +2893,7 @@ class TestHelixGroups(unittest.TestCase):
 
         design_from_json = sc.Design.from_scadnano_json_str(design_json_str)
         self._asserts_for_fixture(design_from_json)
+
 
     def test_helix_groups_fail_nonexistent(self) -> None:
         helices = [
@@ -3544,7 +3566,7 @@ class TestJSON(unittest.TestCase):
         actual_color_hex = d.strands[0].color.to_json_serializable(False)
         self.assertEqual(expected_color_hex, actual_color_hex)
 
-    def test_non_parallel_helices_when_using_single_helix_group(self) -> None:
+    def test_single_helix_group_and_helices_specify_pitch_and_yaw(self) -> None:
         json_str = """
         {
           "helices": [
@@ -3583,7 +3605,7 @@ class TestJSON(unittest.TestCase):
         self.assertEqual(sc.Position3D(1, 2, 3), helix0.position)
         self.assertEqual(5, helix0.roll)
         # Helix 0 should have been moved to a new helix group
-        pitch_25_yaw_19_group_name = f'pitch_25.0_yaw_19.0'
+        pitch_25_yaw_19_group_name = f'pitch_25_yaw_19'
         pitch_25_yaw_19_group = d.groups[pitch_25_yaw_19_group_name]
         self.assertEqual(25, pitch_25_yaw_19_group.pitch)
         self.assertEqual(19, pitch_25_yaw_19_group.yaw)
@@ -3593,8 +3615,242 @@ class TestJSON(unittest.TestCase):
         self.assertEqual("north", helix1.group)
         self.assertEqual(2, len(d.groups))
 
+    def test_only_individual_helices_specify_pitch_and_yaw(self) -> None:
+        json_str = """
+        {
+          "helices": [
+            {
+              "group": "north",
+              "position": {"x": 1, "y": 2, "z": 3},
+              "pitch": 25,
+              "yaw": 19,
+              "roll": 5
+            },
+            {
+              "group": "north",
+              "position": {"x": 3, "y": 2, "z": 3},
+              "pitch": 21,
+              "yaw": 13,
+              "roll": 15
+            }
+          ],
+          "groups": {
+            "north": {
+              "position": {"x": 0, "y": -200, "z": 0},
+              "grid": "none"
+            }
+          },
+          "strands": [ 
+            { 
+              "color": "#0066cc", 
+              "domains": [ {"helix": 0, "forward": true, "start": 0, "end": 32} ]
+            } 
+          ] 
+        }
+        """
+        d = sc.Design.from_scadnano_json_str(json_str)
+        helix0 = d.helices[0]
+        helix1 = d.helices[1]
 
-    def test_non_parallel_helices_when_using_multiple_helix_group(self) -> None:
+        # Helix 0 should have been moved to a new helix group
+        pitch_25_yaw_19_group_name = f'pitch_25.0_yaw_19.0'
+        pitch_25_yaw_19_group = d.groups[pitch_25_yaw_19_group_name]
+        self.assertEqual(sc.Position3D(1, 2, 3), helix0.position)
+        self.assertEqual(25, pitch_25_yaw_19_group.pitch)
+        self.assertEqual(19, pitch_25_yaw_19_group.yaw)
+        self.assertEqual(5, helix0.roll)
+        self.assertEqual(pitch_25_yaw_19_group_name, helix0.group)
+
+
+        # Helix 1 should have been moved to a new helix group
+        pitch_21_yaw_13_group_name = f'pitch_21.0_yaw_13.0'
+        pitch_21_yaw_13_group = d.groups[pitch_21_yaw_13_group_name]
+        self.assertEqual(sc.Position3D(3, 2, 3), helix1.position)
+        self.assertEqual(21, pitch_21_yaw_13_group.pitch)
+        self.assertEqual(13, pitch_21_yaw_13_group.yaw)
+        self.assertEqual(15, helix1.roll)
+        self.assertEqual(pitch_21_yaw_13_group_name, helix1.group)
+
+        self.assertEqual(3, len(d.groups))
+
+
+    def test_only_helix_groups_specify_pitch_and_yaw(self) -> None:
+        json_str = """
+        {
+          "helices": [
+            {
+              "group": "north",
+              "position": {"x": 1, "y": 2, "z": 3},
+              "roll": 5
+            },
+            {
+              "group": "south",
+              "position": {"x": 3, "y": 2, "z": 3},
+              "roll": 15
+            }
+          ],
+          "groups": {
+            "north": {
+              "position": {"x": 0, "y": -200, "z": 0},
+              "pitch": 21,
+              "yaw": 13,
+              "grid": "none"
+            },
+            "south": {
+              "position": {"x": 0, "y": -400, "z": 0},
+              "pitch": 23,
+              "yaw": 98,
+              "grid": "none"
+            }
+          },
+          "strands": [
+            {
+              "color": "#0066cc",
+              "domains": [ {"helix": 0, "forward": true, "start": 0, "end": 32} ]
+            }
+          ]
+        }
+        """
+        d = sc.Design.from_scadnano_json_str(json_str)
+        helix0 = d.helices[0]
+        helix1 = d.helices[1]
+
+        north_str= 'north'
+        south_str = 'south'
+        north_group = d.groups[north_str]
+        south_group = d.groups[south_str]
+        self.assertEqual(2, len(d.groups))
+
+        self.assertEqual(sc.Position3D(1, 2, 3), helix0.position)
+        self.assertEqual(5, helix0.roll)
+        self.assertEqual(21, north_group.pitch)
+        self.assertEqual(13, north_group.yaw)
+        self.assertEqual(north_str, helix0.group)
+
+        self.assertEqual(sc.Position3D(3, 2, 3), helix1.position)
+        self.assertEqual(15, helix1.roll)
+        self.assertEqual(23, south_group.pitch)
+        self.assertEqual(98, south_group.yaw)
+        self.assertEqual(south_str, helix1.group)
+
+
+    def test_both_helix_groups_and_helices_do_not_specify_pitch_nor_yaw(self) -> None:
+        json_str = """
+        {
+          "helices": [
+            {
+              "group": "north",
+              "position": {"x": 1, "y": 2, "z": 3},
+              "roll": 5
+            },
+            {
+              "group": "south",
+              "position": {"x": 3, "y": 2, "z": 3},
+              "roll": 15
+            }
+          ],
+          "groups": {
+            "north": {
+              "position": {"x": 0, "y": -200, "z": 0},
+              "grid": "none"
+            },
+            "south": {
+              "position": {"x": 0, "y": -400, "z": 0},
+              "grid": "none"
+            }
+          },
+          "strands": [
+            {
+              "color": "#0066cc",
+              "domains": [ {"helix": 0, "forward": true, "start": 0, "end": 32} ]
+            }
+          ]
+        }
+        """
+        d = sc.Design.from_scadnano_json_str(json_str)
+        helix0 = d.helices[0]
+        helix1 = d.helices[1]
+
+        north_str= 'north'
+        south_str = 'south'
+        north_group = d.groups[north_str]
+        south_group = d.groups[south_str]
+        self.assertEqual(2, len(d.groups))
+
+        self.assertEqual(sc.Position3D(1, 2, 3), helix0.position)
+        self.assertEqual(5, helix0.roll)
+        self.assertEqual(0, north_group.pitch)
+        self.assertEqual(0, north_group.yaw)
+        self.assertEqual(north_str, helix0.group)
+
+        self.assertEqual(sc.Position3D(3, 2, 3), helix1.position)
+        self.assertEqual(15, helix1.roll)
+        self.assertEqual(0, south_group.pitch)
+        self.assertEqual(0, south_group.yaw)
+        self.assertEqual(south_str, helix1.group)
+
+
+    def test_multiple_helix_groups_helices_specify_pitch_and_yaw(self) -> None:
+        json_str = """
+        {
+          "helices": [
+            {
+              "group": "north",
+              "position": {"x": 1, "y": 2, "z": 3},
+              "pitch": 4,
+              "roll": 5,
+              "yaw": 6            },
+            {
+              "group": "south",
+              "position": {"x": 3, "y": 2, "z": 3},
+              "roll": 15
+            }
+          ],
+          "groups": {
+            "north": {
+              "position": {"x": 0, "y": -200, "z": 0},
+              "pitch": 21,
+              "yaw": 13,
+              "grid": "none"
+            },
+            "south": {
+              "position": {"x": 0, "y": -400, "z": 0},
+              "pitch": 23,
+              "yaw": 98,
+              "grid": "none"
+            }
+          },
+          "strands": [
+            {
+              "color": "#0066cc",
+              "domains": [ {"helix": 0, "forward": true, "start": 0, "end": 32} ]
+            }
+          ]
+        }
+        """
+        d = sc.Design.from_scadnano_json_str(json_str)
+        helix0 = d.helices[0]
+        helix1 = d.helices[1]
+
+        north_str = 'north'
+        south_str = 'south'
+        north_group = d.groups[north_str]
+        south_group = d.groups[south_str]
+        self.assertEqual(2, len(d.groups))
+
+        self.assertEqual(sc.Position3D(1, 2, 3), helix0.position)
+        self.assertEqual(5, helix0.roll)
+        self.assertEqual(25, north_group.pitch)
+        self.assertEqual(19, north_group.yaw)
+        self.assertEqual(north_str, helix0.group)
+
+        self.assertEqual(sc.Position3D(3, 2, 3), helix1.position)
+        self.assertEqual(15, helix1.roll)
+        self.assertEqual(23, south_group.pitch)
+        self.assertEqual(98, south_group.yaw)
+        self.assertEqual(south_str, helix1.group)
+
+    def test_multiple_helix_groups_helices_specify_pitch_and_yaw_invalid(self) -> None:
         json_str = """
         {
           "helices": [
@@ -3632,6 +3888,7 @@ class TestJSON(unittest.TestCase):
           ] 
         }
         """
+        # Should fail because multiple helices in same helix group are non-parallel
         with self.assertRaises(sc.IllegalDesignError):
             sc.Design.from_scadnano_json_str(json_str)
 
@@ -3660,7 +3917,7 @@ class TestJSON(unittest.TestCase):
         expected_roll = 5
         expected_yaw = 6
         actual_position = d.helices[0].position
-        expected_group_name = f'pitch_{expected_pitch}.0_yaw_{expected_yaw}.0'
+        expected_group_name = f'pitch_{expected_pitch}_yaw_{expected_yaw}'
         expected_group = d.groups[expected_group_name]
         actual_pitch = expected_group.pitch
         actual_roll = d.helices[0].roll

--- a/tests_inputs/cadnano_v2_export/test_16_helix_origami_rectangle_no_twist.sc
+++ b/tests_inputs/cadnano_v2_export/test_16_helix_origami_rectangle_no_twist.sc
@@ -1,5 +1,5 @@
 {
-  "version": "0.15.0",
+  "version": "0.16.0",
   "grid": "square",
   "helices": [
     {"max_offset": 448, "grid_position": [0, 0]},

--- a/tests_inputs/cadnano_v2_export/test_2_stape_2_helix_origami_deletions_insertions.sc
+++ b/tests_inputs/cadnano_v2_export/test_2_stape_2_helix_origami_deletions_insertions.sc
@@ -1,5 +1,5 @@
 {
-  "version": "0.15.0",
+  "version": "0.16.0",
   "grid": "square",
   "helices": [
     {"grid_position": [0, 0]},

--- a/tests_inputs/cadnano_v2_export/test_2_stape_2_helix_origami_extremely_simple.sc
+++ b/tests_inputs/cadnano_v2_export/test_2_stape_2_helix_origami_extremely_simple.sc
@@ -1,5 +1,5 @@
 {
-  "version": "0.15.0",
+  "version": "0.16.0",
   "grid": "square",
   "helices": [
     {"grid_position": [0, 0]},

--- a/tests_inputs/cadnano_v2_export/test_2_stape_2_helix_origami_extremely_simple_2.sc
+++ b/tests_inputs/cadnano_v2_export/test_2_stape_2_helix_origami_extremely_simple_2.sc
@@ -1,5 +1,5 @@
 {
-  "version": "0.15.0",
+  "version": "0.16.0",
   "grid": "square",
   "helices": [
     {"grid_position": [0, 0]},

--- a/tests_inputs/cadnano_v2_export/test_6_helix_origami_rectangle.sc
+++ b/tests_inputs/cadnano_v2_export/test_6_helix_origami_rectangle.sc
@@ -1,5 +1,5 @@
 {
-  "version": "0.15.0",
+  "version": "0.16.0",
   "grid": "square",
   "helices": [
     {"max_offset": 192, "grid_position": [0, 0]},

--- a/tests_inputs/cadnano_v2_export/test_circular_strand.sc
+++ b/tests_inputs/cadnano_v2_export/test_circular_strand.sc
@@ -1,5 +1,5 @@
 {
-  "version": "0.15.0",
+  "version": "0.16.0",
   "grid": "square",
   "helices": [
     {"max_offset": 24, "grid_position": [0, 0]},

--- a/tests_inputs/cadnano_v2_export/test_export_design_with_helix_group.sc
+++ b/tests_inputs/cadnano_v2_export/test_export_design_with_helix_group.sc
@@ -1,5 +1,5 @@
 {
-  "version": "0.15.0",
+  "version": "0.16.0",
   "groups": {
     "east": {
       "position": {"x": 10, "y": 0, "z": 0},

--- a/tests_inputs/cadnano_v2_export/test_export_design_with_helix_group_not_same_grid.sc
+++ b/tests_inputs/cadnano_v2_export/test_export_design_with_helix_group_not_same_grid.sc
@@ -1,5 +1,5 @@
 {
-  "version": "0.15.0",
+  "version": "0.16.0",
   "groups": {
     "east": {
       "position": {"x": 10, "y": 0, "z": 0},


### PR DESCRIPTION
# DO NOT MERGE YET

I still have not implemented a Design method for looking up pitch/yaw/roll values for helices. Should be straightforward, but any name suggestions for the function names? Maybe `Design.{pitch/yaw/roll}_of_helix`?

The second reason for not merging yet is because I added code in `Design.json` to allow for compatibility with designs that specified pitch and yaw in individual Helix. It passes all of the old test cases as well as news one I made, but I am concerned about the quality of the implementation so I would like to give @dave-doty an opportunity to review the code.

## Completed:
* Remove Helix.pitch and Helix.yaw
* Update Design.from_json to be compatible with designs that specified
  pitch and yaw in individual Helix (except when multiple helices in the
  same group have different pitch/yaw values, in which case,
  IllegalDesignError is raised)
* Updated examples that used pitch and roll
* Updated unit tests that used pitch/roll
* Added new unit test to test new Design.from_json

## Not Completed:
* Add Design method for looking up pitch/yaw/roll for helices