### PR TITLE
Only remove "Grid." from grid if it is there.

### DIFF
--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -4079,7 +4079,10 @@ class Design(_JSONSerializable, Generic[StrandLabel, DomainLabel]):
         dct[version_key] = __version__
 
         if self._has_default_groups():
-            dct[grid_key] = str(self.grid)[5:]  # remove prefix 'Grid.'
+            if str(self.grid).startswith('Grid.'):
+                dct[grid_key] = str(self.grid)[5:]  # remove prefix 'Grid.'
+            else:
+                dct[grid_key] = str(self.grid)
 
         if not self.geometry.is_default():
             dct[geometry_key] = self.geometry.to_json_serializable(suppress_indent)


### PR DESCRIPTION
On write, if writing a "grid" value, only remove "Grid." from the string
represe ntation if it is actually there.  It is not for me (with Python
3.9): I'm not sure whether this is a general bug in the package (in
which case the conditional could be removed) or if it is a
version-dependent change in behaviour.