### PR TITLE
Encoder indent suppression: str.replace → re.sub (fixes #170)

### DIFF
--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -126,7 +126,7 @@ class _SuppressableIndentEncoder(json.JSONEncoder):
         super(_SuppressableIndentEncoder, self).__init__(*args, **kwargs)
         self.kwargs = dict(kwargs)
         del self.kwargs['indent']
-        self._replacement_map: Dict[int, Any] = {}
+        self._replacement_map: Dict[int, str] = {}
 
     def default(self, obj: Any) -> Any:
         if isinstance(obj, NoIndent):
@@ -140,9 +140,7 @@ class _SuppressableIndentEncoder(json.JSONEncoder):
 
     def encode(self, obj: Any) -> Any:
         result = super().encode(obj)
-        for k, v in self._replacement_map.items():
-            result = result.replace(f'"@@{k}@@"', v)
-        return result
+        return re.sub(r'"@@(\d+)@@"', lambda m: self._replacement_map[int(m[1])], result)
 
 
 #


### PR DESCRIPTION
Using re.sub (re is already imported), along with a replacement function that pulls from the replacement map, avoids repeated string replacements within Python and significantly speeds up encoding for large files.  Note that I think this will raise a KeyError if the user has something with a name fitting "@@(\d+)@@" where the number is larger than the largest unique_id, and will corrupt the file if it is not. However, this is similar to the current situation, where I think it will never raise an error, but could corrupt the file.

This also changes the type of _replacement_map to avoid a mypy warning: it should be a correct narrowing of the value from Any to str, however.

Trying this with the design I'm trying to repeatedly save, the change brings write time down from 20 seconds to a little over 1 second.