### PR TITLE
fix purification/scale typo in to_idt_bulk_input_format

### DIFF
--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -5312,7 +5312,7 @@ class Design(_JSONSerializable, Generic[StrandLabel, DomainLabel]):
                                      f'this strand should have been filtered out by _idt_strands_to_export')
             if strand.idt is not None:
                 scale = strand.idt.scale
-                purification = strand.idt.scale
+                purification = strand.idt.purification
             else:
                 scale = default_idt_scale
                 purification = default_idt_purification


### PR DESCRIPTION
minor typo here in the export that puts the scale both where it should be and where the purification should be