### PR TITLE
Oxdna export roll angle fix

### DIFF
--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -6646,7 +6646,7 @@ def _oxdna_get_helix_vectors(design: Design, helix: Helix) -> Tuple[_OxdnaVector
     forward = forward.rotate(design.yaw_of_helix(helix), normal)
     forward = forward.rotate(-design.pitch_of_helix(helix), _OxdnaVector(1, 0, 0))
     normal = normal.rotate(-design.pitch_of_helix(helix), _OxdnaVector(1, 0, 0))
-    normal = normal.rotate(helix.roll, forward)
+    normal = normal.rotate(-helix.roll, forward)
 
     x: float = 0.0
     y: float = 0.0

--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -6646,6 +6646,7 @@ def _oxdna_get_helix_vectors(design: Design, helix: Helix) -> Tuple[_OxdnaVector
     forward = forward.rotate(design.yaw_of_helix(helix), normal)
     forward = forward.rotate(-design.pitch_of_helix(helix), _OxdnaVector(1, 0, 0))
     normal = normal.rotate(-design.pitch_of_helix(helix), _OxdnaVector(1, 0, 0))
+    
     normal = normal.rotate(-helix.roll, forward)
 
     x: float = 0.0


### PR DESCRIPTION
When applying the roll angle to a helix, the function _oxdna_get_helix_vectors was applying the roll angle in the wrong orientation (counterclockwise instead of clockwise). This fix simply flips the direction in which the roll is applied.