### PR TITLE
Fixes #205; make xlwt a dependency for pip installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,8 @@ setup(name='scadnano',
       long_description=long_description,
       long_description_content_type='text/markdown; variant=GFM',
       python_requires='>=3.6',
-      requires=['xlwt'],
       install_requires=[
+        'xlwt',
         'dataclasses>=0.6;python_version<"3.7"'
       ]
 )


### PR DESCRIPTION
## Description
Moved 'xlwt' from `requires` to `install_requires`. [Dependencies are supposed to be specified in install_requires](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#dependency-management). I couldn't find a clear reason why `requires` is not valid, but I do see in the [setuptools keywords page](https://setuptools.pypa.io/en/latest/references/keywords.html) that:

> requires is superseded by install_requires and should not be used anymore.

## Related Issue
#205 

## Motivation and Context
Currently, `xlwt` is not installed when scadnano is installed using `pip`.

## How Has This Been Tested?
Setup: Used new setup.py to make new PyPI test package: https://pypi.org/project/scadnano-test/

1. Uninstall xlwt with `pip uninstall xlwt`
2. Install scadnano-test `pip install scadnano-test`
3. Open a python shell and ran `import xlwt` and verified no import error, so xlwt is installed
