### PR TITLE
Bump version to 0.17.1

### DIFF
--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -54,7 +54,7 @@ so the user must take care not to set them.
 # commented out for now to support Py3.6, which does not support this feature
 # from __future__ import annotations
 
-__version__ = "0.17.0"  # version line; WARNING: do not remove or change this line or comment
+__version__ = "0.17.1"  # version line; WARNING: do not remove or change this line or comment
 
 import dataclasses
 from abc import abstractmethod, ABC, ABCMeta


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Bump version to 0.17.1

## Motivation and Context
[scadnano 0.17.0](https://pypi.org/project/scadnano/0.17.0/) was mistakenly deployed to PyPI so can no longer be pushed to.