### PR TITLE
stap_loop -> stapLoop in cadnano export 

### DIFF
--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -4940,7 +4940,7 @@ class Design(_JSONSerializable, Generic[StrandLabel, DomainLabel]):
 
             helix_dct['stap_colors'] = []
             helix_dct['scafLoop'] = []
-            helix_dct['stap_loop'] = []
+            helix_dct['stapLoop'] = []
 
             helices_ids_reverse[helix_dct['num']] = i
             dct['vstrands'].append(helix_dct)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A typo was present in cadnano2 export code where key "stap_loop" was used instead of "stapLoop".


