### PR TITLE
#210 generate plate map

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(name='scadnano',
       python_requires='>=3.6',
       install_requires=[
         'xlwt',
-        'dataclasses>=0.6;python_version<"3.7"'
+        'dataclasses>=0.6;python_version<"3.7"',
+        'tabulate',
       ]
 )


### PR DESCRIPTION
If IDT fields are specified with plate and well positions, scadnano should be able to write a plate map showing strand names in the well positions.

## Description
The method `Design.plate_maps_markdown` was implemented, which outputs Markdown representations of plate maps.

## Related Issue
#210

## Motivation and Context
This helps to organize and visualize strands in an experiment by visually laying out where the strands are in a 96-well or 384-well plate.

## How Has This Been Tested?
No unit tests. The example in the issue #210 was run, and some other examples for a current wet lab project.

## Screenshots (if appropriate):
