### PR TITLE
closes #219: change `Design.strand` to `Design.draw_strand`

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,14 +232,14 @@ def create_design():
 
     # for absolute offsets, call method "to"
     # left staple
-    design.strand(1, 8).to(24).cross(0).to(8)
+    design.draw_strand(1, 8).to(24).cross(0).to(8)
 
     # for relative offsets, call method "move"
     # right staple
-    design.strand(0, 40).move(-16).cross(1).move(16).with_modification_5p(mod.biotin_5p)
+    design.draw_strand(0, 40).move(-16).cross(1).move(16).with_modification_5p(mod.biotin_5p)
 
     # scaffold
-    design.strand(1, 24).move(-16).cross(0).move(32).loopout(1, 3).move(-16).as_scaffold()
+    design.draw_strand(1, 24).move(-16).cross(0).move(32).loopout(1, 3).move(-16).as_scaffold()
 
     # deletions and insertions added to design are added to both strands on a helix
     design.add_deletion(helix=1, offset=20)
@@ -257,7 +257,7 @@ if __name__ == '__main__':
     design.write_scadnano_file(directory='output_designs')
 ```
 
-Documentation is available in the [API docs](https://scadnano-python-package.readthedocs.io/en/latest/#scadnano.Design.strand).
+Documentation is available in the [API docs](https://scadnano-python-package.readthedocs.io/en/latest/#scadnano.Design.draw_strand).
 
 
 

--- a/examples/2_staple_2_helix_origami_deletions_insertions_mods_chained_methods.py
+++ b/examples/2_staple_2_helix_origami_deletions_insertions_mods_chained_methods.py
@@ -9,9 +9,9 @@ def create_design() -> sc.Design:
     # whole design
     design = sc.Design(helices=helices, strands=[], grid=sc.square)
 
-    design.strand(1, 8).to(24).cross(0).to(8) # left staple
-    design.strand(0, 40).to(24).cross(1).to(40).with_modification_5p(mod.biotin_5p) # right staple
-    design.strand(1, 24).to(8).cross(0).to(40).loopout(1, 3).to(24).as_scaffold()
+    design.draw_strand(1, 8).to(24).cross(0).to(8) # left staple
+    design.draw_strand(0, 40).to(24).cross(1).to(40).with_modification_5p(mod.biotin_5p) # right staple
+    design.draw_strand(1, 24).to(8).cross(0).to(40).loopout(1, 3).to(24).as_scaffold()
 
     # deletions and insertions added to design are added to both strands on a helix
     design.add_deletion(helix=1, offset=20)

--- a/examples/circular.py
+++ b/examples/circular.py
@@ -5,9 +5,9 @@ def create_design() -> sc.Design:
     helices = [sc.Helix(max_offset=24) for _ in range(2)]
     design = sc.Design(helices=helices, grid=sc.square)
 
-    design.strand(0,0).move(8).cross(1).move(-8).as_circular()
-    design.strand(0,8).move(8).loopout(1, 5).move(-8).as_circular()
-    design.strand(0,16).move(8).cross(1).move(-8)
+    design.draw_strand(0, 0).move(8).cross(1).move(-8).as_circular()
+    design.draw_strand(0, 8).move(8).loopout(1, 5).move(-8).as_circular()
+    design.draw_strand(0, 16).move(8).cross(1).move(-8)
 
     return design
 

--- a/examples/helix_groups.py
+++ b/examples/helix_groups.py
@@ -48,25 +48,25 @@ def create_design() -> sc.Design:
 
     design = sc.Design(helices=helices, groups=groups, strands=[])
 
-    design.strand(0, 0).to(8) \
+    design.draw_strand(0, 0).to(8) \
         .cross(1).to(0) \
         .cross(2).to(8) \
         .cross(3).to(0) \
         .cross(4).to(8) \
         .cross(5).to(0)
 
-    design.strand(4, 10).to(13)
+    design.draw_strand(4, 10).to(13)
 
-    design.strand(6, 0).to(8).cross(7).to(0)
-    design.strand(8, 0).to(8).cross(9).to(0)
-    design.strand(13, 0).to(8).cross(15).to(0)
+    design.draw_strand(6, 0).to(8).cross(7).to(0)
+    design.draw_strand(8, 0).to(8).cross(9).to(0)
+    design.draw_strand(13, 0).to(8).cross(15).to(0)
 
-    design.strand(8, 8).to(11)
-    design.strand(13, 8).to(11)
+    design.draw_strand(8, 8).to(11)
+    design.draw_strand(13, 8).to(11)
 
 
     if include_rot:
-        design.strand(10, 0).to(8).cross(11).to(0)
+        design.draw_strand(10, 0).to(8).cross(11).to(0)
 
     return design
 

--- a/examples/names_domains_strands.py
+++ b/examples/names_domains_strands.py
@@ -5,7 +5,7 @@ def create_design() -> sc.Design:
     num_domains = 9
     helices = [sc.Helix(max_offset=(num_domains) * 8)]
     design: sc.Design = sc.Design(helices=helices, strands=[], grid=sc.square)
-    design.strand(0, (num_domains - 1) * 8) \
+    design.draw_strand(0, (num_domains - 1) * 8) \
         .move(-8).with_domain_name('domain 8*') \
         .move(-8).with_domain_name('domain 7*') \
         .move(-8).with_domain_name('domain 6*') \
@@ -17,25 +17,25 @@ def create_design() -> sc.Design:
         .with_name('bottom strand')
 
     # domain names match
-    design.strand(0, 0).move(8).with_domain_name('domain 1').with_name('top strand 1')
+    design.draw_strand(0, 0).move(8).with_domain_name('domain 1').with_name('top strand 1')
 
     # domains are aligns but names mismatch
-    design.strand(0, 8).move(8).with_domain_name('domain 50').with_name('top strand 2')
+    design.draw_strand(0, 8).move(8).with_domain_name('domain 50').with_name('top strand 2')
 
     # domain names match
-    design.strand(0, 16).move(8).with_domain_name('domain 3').with_name('top strand 3')
+    design.draw_strand(0, 16).move(8).with_domain_name('domain 3').with_name('top strand 3')
 
     # domain names are the same, not complementary
-    design.strand(0, 24).move(8).with_domain_name('domain 4*').with_name('top strand 4')
+    design.draw_strand(0, 24).move(8).with_domain_name('domain 4*').with_name('top strand 4')
 
     # domain names match but domains are mis-aligned
-    design.strand(0, 32).move(9).with_domain_name('domain 5').with_name('top strand 5')
+    design.draw_strand(0, 32).move(9).with_domain_name('domain 5').with_name('top strand 5')
 
     # domain names match but domains are mis-aligned
-    design.strand(0, 48).move(7).with_domain_name('domain 7').with_name('top strand 7')
+    design.draw_strand(0, 48).move(7).with_domain_name('domain 7').with_name('top strand 7')
 
     # no overlap so no mismatch
-    design.strand(0, 64).move(8).with_domain_name('domain 9').with_name('top strand 9')
+    design.draw_strand(0, 64).move(8).with_domain_name('domain 9').with_name('top strand 9')
 
     return design
 

--- a/examples/tutorial-examples/24_helix_rectangle.py
+++ b/examples/tutorial-examples/24_helix_rectangle.py
@@ -26,11 +26,11 @@ def create_design() -> sc.Design:
 
 def add_scaffold_precursors(design: sc.Design) -> None:
     for helix in range(0, 23, 2):  # scaffold goes forward on even helices
-        design.strand(helix, 0).move(288).as_scaffold()
+        design.draw_strand(helix, 0).move(288).as_scaffold()
     for helix in range(1, 23, 2):  # scaffold goes reverse on odd helices
-        design.strand(helix, 288).move(-288).as_scaffold()
-    design.strand(23, 288).move(-144).as_scaffold()  # bottom part of scaffold has a "nick"
-    design.strand(23, 144).move(-144).as_scaffold()  #
+        design.draw_strand(helix, 288).move(-288).as_scaffold()
+    design.draw_strand(23, 288).move(-144).as_scaffold()  # bottom part of scaffold has a "nick"
+    design.draw_strand(23, 144).move(-144).as_scaffold()  #
 
 
 def add_scaffold_crossovers(design: sc.Design) -> None:

--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -862,8 +862,8 @@ class Modification(_JSONSerializable, ABC):
     .. code-block:: python
 
         biotin_5p = Modification5Prime(display_text='B', idt_text='/5Biosg/')
-        design.strand(0, 0).move(8).with_modification_5p(biotin_5p)
-        design.strand(1, 0).move(8).with_modification_5p(biotin_5p)
+        design.draw_strand(0, 0).move(8).with_modification_5p(biotin_5p)
+        design.draw_strand(1, 0).move(8).with_modification_5p(biotin_5p)
     """
 
     display_text: str
@@ -931,8 +931,8 @@ class Modification5Prime(Modification):
     .. code-block:: python
 
         biotin_5p = Modification5Prime(display_text='B', idt_text='/5Biosg/')
-        design.strand(0, 0).move(8).with_modification_5p(biotin_5p)
-        design.strand(1, 0).move(8).with_modification_5p(biotin_5p)
+        design.draw_strand(0, 0).move(8).with_modification_5p(biotin_5p)
+        design.draw_strand(1, 0).move(8).with_modification_5p(biotin_5p)
     """
 
     def to_json_serializable(self, suppress_indent: bool = True, **kwargs: Any) -> Dict[str, Any]:
@@ -968,8 +968,8 @@ class Modification3Prime(Modification):
     .. code-block:: python
 
         biotin_3p = Modification3Prime(display_text='B', idt_text='/3Bio/')
-        design.strand(0, 0).move(8).with_modification_3p(biotin_3p)
-        design.strand(1, 0).move(8).with_modification_3p(biotin_3p)
+        design.draw_strand(0, 0).move(8).with_modification_3p(biotin_3p)
+        design.draw_strand(1, 0).move(8).with_modification_3p(biotin_3p)
     """
 
     def to_json_serializable(self, suppress_indent: bool = True, **kwargs: Any) -> Dict[str, Any]:
@@ -1948,7 +1948,7 @@ class Loopout(_JSONSerializable, Generic[DomainLabel]):
         import scadnano as sc
 
         design = sc.Design(helices=[sc.Helix(max_offset=10)])
-        design.strand(0,0).move(10).loopout(0,5).move(-10)
+        design.draw_strand(0,0).move(10).loopout(0,5).move(-10)
     """
 
     length: int
@@ -2150,7 +2150,7 @@ class StrandBuilder(Generic[StrandLabel, DomainLabel]):
 
     .. code-block:: Python
 
-        design.strand(0, 0).to(10).cross(1).to(5).with_modification_5p(mod.biotin_5p).as_scaffold()
+        design.draw_strand(0, 0).to(10).cross(1).to(5).with_modification_5p(mod.biotin_5p).as_scaffold()
 
     :any:`StrandBuilder` should generally not be created directly.
     Although it is convenient to use chained method calls, it is also sometimes useful to assign the
@@ -2159,7 +2159,7 @@ class StrandBuilder(Generic[StrandLabel, DomainLabel]):
 
     .. code-block:: Python
 
-        strand_builder = design.strand(0, 0)
+        strand_builder = design.draw_strand(0, 0)
         strand_builder.to(10)
         strand_builder.cross(1)
         strand_builder.to(5)
@@ -2456,7 +2456,7 @@ class StrandBuilder(Generic[StrandLabel, DomainLabel]):
 
         .. code-block:: Python
 
-            design.strand(0, 0).to(10).cross(1).to(5).with_sequence('AAAAAAAAAACGCGC')
+            design.draw_strand(0, 0).to(10).cross(1).to(5).with_sequence('AAAAAAAAAACGCGC')
 
         :param sequence: the DNA sequence to assign to the :any:`Strand`
         :param assign_complement: whether to automatically assign the complement to existing :any:`Strand`'s
@@ -2483,7 +2483,7 @@ class StrandBuilder(Generic[StrandLabel, DomainLabel]):
 
         .. code-block:: Python
 
-            design.strand(0, 5).to(8).with_domain_sequence('AAA')\\
+            design.draw_strand(0, 5).to(8).with_domain_sequence('AAA')\\
                 .cross(1).to(5).with_domain_sequence('TTT')\\
                 .loopout(2, 4).with_domain_sequence('CCCC')\\
                 .to(10).with_domain_sequence('GGGGG')
@@ -2508,7 +2508,7 @@ class StrandBuilder(Generic[StrandLabel, DomainLabel]):
 
         .. code-block:: Python
 
-            design.strand(0, 0).to(10).cross(1).to(5).with_name('scaffold')
+            design.draw_strand(0, 0).to(10).cross(1).to(5).with_name('scaffold')
 
         :param name: name to assign to the :any:`Strand`
         :return: self
@@ -2525,7 +2525,7 @@ class StrandBuilder(Generic[StrandLabel, DomainLabel]):
 
         .. code-block:: Python
 
-            design.strand(0, 0).to(10).cross(1).to(5).with_label('scaffold')
+            design.draw_strand(0, 0).to(10).cross(1).to(5).with_label('scaffold')
 
         :param label: label to assign to the :any:`Strand`
         :return: self
@@ -2548,7 +2548,7 @@ class StrandBuilder(Generic[StrandLabel, DomainLabel]):
 
         .. code-block:: Python
 
-            design.strand(0, 0).to(10).with_domain_name('dom1*').cross(1).to(5).with_domain_name('dom1')
+            design.draw_strand(0, 0).to(10).with_domain_name('dom1*').cross(1).to(5).with_domain_name('dom1')
 
         :param name: name to assign to the most recently created :any:`Domain` or :any:`Loopout`
         :return: self
@@ -2572,7 +2572,7 @@ class StrandBuilder(Generic[StrandLabel, DomainLabel]):
 
         .. code-block:: Python
 
-            design.strand(0, 5).to(8).with_domain_label('domain 1')\\
+            design.draw_strand(0, 5).to(8).with_domain_label('domain 1')\\
                 .cross(1).to(5).with_domain_label('domain 2')\\
                 .loopout(2, 4).with_domain_label('domain 3')\\
                 .to(10).with_domain_label('domain 4')
@@ -3925,7 +3925,7 @@ class Design(_JSONSerializable, Generic[StrandLabel, DomainLabel]):
                 grid_for_group = group.grid
             group.helices_view_order = _check_helices_view_order_and_return(helices_view_order_for_group,
                                                                             helix_idxs_in_group)
-            
+
             if grid_for_group is None:
                 raise AssertionError()
             group.grid = grid_for_group
@@ -4394,7 +4394,7 @@ class Design(_JSONSerializable, Generic[StrandLabel, DomainLabel]):
 
         for idx, helix in helices.items():
             helix.idx = idx
-        
+
         return helices
 
     @staticmethod
@@ -4788,7 +4788,6 @@ class Design(_JSONSerializable, Generic[StrandLabel, DomainLabel]):
         for strand in strands_in_plate:
             well_to_strand[strand.idt.well] = strand
 
-
         num_rows = len(plate_type.rows())
         num_cols = len(plate_type.cols())
         header = [' '] + [str(col) for col in plate_type.cols()]
@@ -4896,7 +4895,7 @@ class Design(_JSONSerializable, Generic[StrandLabel, DomainLabel]):
             ]))
 
         Each call to
-        :py:meth:`Design.strand`,
+        :py:meth:`Design.draw_strand`,
         :py:meth:`StrandBuilder.cross`,
         :py:meth:`StrandBuilder.loopout`,
         :py:meth:`StrandBuilder.to`

--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -54,7 +54,7 @@ so the user must take care not to set them.
 # commented out for now to support Py3.6, which does not support this feature
 # from __future__ import annotations
 
-__version__ = "0.17.1"  # version line; WARNING: do not remove or change this line or comment
+__version__ = "0.17.2"  # version line; WARNING: do not remove or change this line or comment
 
 import dataclasses
 from abc import abstractmethod, ABC, ABCMeta
@@ -4918,16 +4918,16 @@ class Design(_JSONSerializable, Generic[StrandLabel, DomainLabel]):
         """
         return StrandBuilder(self, helix, offset)
 
-    # def strand(self, helix: int, offset: int) -> StrandBuilder:
-    #     """
-    #     Same as :meth:`Design.draw_strand`.
-    #
-    #     .. deprecated:: 0.18.0
-    #        Use :meth:`Design.draw_strand` instead. This method will be removed.
-    #     """
-    #     print('WARNING: The method Design.strand is deprecated. Use Design.draw_strand instead, '
-    #           'which has the same functionality.')
-    #     return self.draw_strand(helix, offset)
+    def strand(self, helix: int, offset: int) -> StrandBuilder:
+        """
+        Same functionality as :meth:`Design.draw_strand`.
+
+        .. deprecated:: 0.17.2
+           Use :meth:`Design.draw_strand` instead. This method will be removed in a future version.
+        """
+        print('WARNING: The method Design.strand is deprecated. Use Design.draw_strand instead, '
+              'which has the same functionality. Design.strand will be removed in a future version.')
+        return self.draw_strand(helix, offset)
 
     def assign_m13_to_scaffold(self, rotation: int = 5587, variant: M13Variant = M13Variant.p7249) -> None:
         """Assigns the scaffold to be the sequence of M13: :py:func:`m13` with the given `rotation`

--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -4859,14 +4859,14 @@ class Design(_JSONSerializable, Generic[StrandLabel, DomainLabel]):
                 raise IllegalDesignError(f'two different modifications share the id {mod.id}; '
                                          f'one is\n  {mod}\nand the other is\n  {other_mod}')
 
-    def strand(self, helix: int, offset: int) -> StrandBuilder:
+    def draw_strand(self, helix: int, offset: int) -> StrandBuilder:
         """Used for chained method building by calling
         :py:meth:`Design.strand` to build the :any:`Strand` domain by domain, in order from 5' to 3'.
         For example
 
         .. code-block:: Python
 
-            design.strand(0, 7).to(10).cross(1).to(5).cross(2).to(15)
+            design.draw_strand(0, 7).to(10).cross(1).to(5).cross(2).to(15)
 
         This creates a :any:`Strand` in this :any:`Design` equivalent to
 
@@ -4882,7 +4882,7 @@ class Design(_JSONSerializable, Generic[StrandLabel, DomainLabel]):
 
         .. code-block:: Python
 
-            design.strand(0, 7).to(10).cross(1).to(5).loopout(2, 3).to(15)
+            design.draw_strand(0, 7).to(10).cross(1).to(5).loopout(2, 3).to(15)
 
         This creates a :any:`Strand` in this :any:`Design` equivalent to
 
@@ -4917,6 +4917,17 @@ class Design(_JSONSerializable, Generic[StrandLabel, DomainLabel]):
         :return: :any:`StrandBuilder` object representing the partially completed :any:`Strand`
         """
         return StrandBuilder(self, helix, offset)
+
+    # def strand(self, helix: int, offset: int) -> StrandBuilder:
+    #     """
+    #     Same as :meth:`Design.draw_strand`.
+    #
+    #     .. deprecated:: 0.18.0
+    #        Use :meth:`Design.draw_strand` instead. This method will be removed.
+    #     """
+    #     print('WARNING: The method Design.strand is deprecated. Use Design.draw_strand instead, '
+    #           'which has the same functionality.')
+    #     return self.draw_strand(helix, offset)
 
     def assign_m13_to_scaffold(self, rotation: int = 5587, variant: M13Variant = M13Variant.p7249) -> None:
         """Assigns the scaffold to be the sequence of M13: :py:func:`m13` with the given `rotation`

--- a/tests/scadnano_tests.py
+++ b/tests/scadnano_tests.py
@@ -41,7 +41,7 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__loopouts_with_labels(self) -> None:
         design = self.design_6helix
-        sb = design.strand(0, 0)
+        sb = design.draw_strand(0, 0)
         sb.to(10)
         sb.loopout(1, 8)
         sb.with_domain_label('loop0')
@@ -66,7 +66,7 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__loopouts_with_labels_to_json(self) -> None:
         design = self.design_6helix
-        sb = design.strand(0, 0)
+        sb = design.draw_strand(0, 0)
         sb.to(10)
         sb.loopout(1, 8)
         sb.with_domain_label('loop0')
@@ -93,7 +93,7 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__0_0_to_10_cross_1_to_5(self) -> None:
         design = self.design_6helix
-        sb = design.strand(0, 0)
+        sb = design.draw_strand(0, 0)
         sb.to(10)
         sb.cross(1)
         sb.to(5)
@@ -112,7 +112,7 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__0_0_to_10_cross_1_to_5__reverse(self) -> None:
         design = self.design_6helix
-        design.strand(1, 5).to(10).cross(0).to(0)
+        design.draw_strand(1, 5).to(10).cross(0).to(0)
         expected_strand = sc.Strand([
             sc.Domain(1, True, 5, 10),
             sc.Domain(0, False, 0, 10),
@@ -128,7 +128,7 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__h0_off0_to_off10_cross_h1_to_off5_loopout_length3_h2_to_off15(self) -> None:
         design = self.design_6helix
-        sb = design.strand(0, 0)
+        sb = design.draw_strand(0, 0)
         sb.to(10)
         sb.cross(1)
         sb.to(5)
@@ -151,7 +151,7 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__two_forward_paranemic_crossovers(self) -> None:
         design = self.design_6helix
-        design.strand(0, 0).to(10).cross(1).to(15).cross(2).to(20)
+        design.draw_strand(0, 0).to(10).cross(1).to(15).cross(2).to(20)
         expected_strand = sc.Strand([
             sc.Domain(0, True, 0, 10),
             sc.Domain(1, True, 10, 15),
@@ -168,7 +168,7 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__two_reverse_paranemic_crossovers(self) -> None:
         design = self.design_6helix
-        design.strand(0, 20).to(10).cross(1).to(5).cross(2).to(0)
+        design.draw_strand(0, 20).to(10).cross(1).to(5).cross(2).to(0)
         expected_strand = sc.Strand([
             sc.Domain(0, False, 10, 20),
             sc.Domain(1, False, 5, 10),
@@ -185,8 +185,8 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__multiple_strands(self) -> None:
         design = self.design_6helix
-        design.strand(0, 0).to(10).cross(1).to(0)
-        design.strand(0, 20).to(10).cross(1).to(20)
+        design.draw_strand(0, 0).to(10).cross(1).to(0)
+        design.draw_strand(0, 20).to(10).cross(1).to(20)
         expected_strand0 = sc.Strand([
             sc.Domain(0, True, 0, 10),
             sc.Domain(1, False, 0, 10),
@@ -207,8 +207,8 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__multiple_strands_other_order(self) -> None:
         design = self.design_6helix
-        design.strand(0, 20).to(10).cross(1).to(20)
-        design.strand(0, 0).to(10).cross(1).to(0)
+        design.draw_strand(0, 20).to(10).cross(1).to(20)
+        design.draw_strand(0, 0).to(10).cross(1).to(0)
         expected_strand0 = sc.Strand([
             sc.Domain(0, False, 10, 20),
             sc.Domain(1, True, 10, 20),
@@ -229,10 +229,10 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__multiple_strands_overlap_no_error(self) -> None:
         design = self.design_6helix
-        design.strand(0, 0).to(10).cross(1).to(0) \
+        design.draw_strand(0, 0).to(10).cross(1).to(0) \
             .as_scaffold() \
             .with_modification_internal(5, mod.cy3_int, warn_on_no_dna=False)
-        design.strand(0, 10).to(0).cross(1).to(10).with_modification_5p(mod.biotin_5p)
+        design.draw_strand(0, 10).to(0).cross(1).to(10).with_modification_5p(mod.biotin_5p)
         expected_strand0 = sc.Strand([
             sc.Domain(0, True, 0, 10),
             sc.Domain(1, False, 0, 10),
@@ -266,13 +266,13 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__multiple_strands_overlap_error(self) -> None:
         design = self.design_6helix
-        design.strand(0, 0).to(10).cross(1).to(0)
+        design.draw_strand(0, 0).to(10).cross(1).to(0)
         with self.assertRaises(sc.IllegalDesignError):
-            design.strand(0, 2).to(8)
+            design.draw_strand(0, 2).to(8)
 
     def test_strand__call_to_twice_legally(self) -> None:
         design = self.design_6helix
-        sb = design.strand(0, 0)
+        sb = design.draw_strand(0, 0)
         sb.to(10)
         sb.cross(1)
         sb.to(5)
@@ -293,7 +293,7 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__call_update_to_twice_legally(self) -> None:
         design = self.design_6helix
-        sb = design.strand(0, 0)
+        sb = design.draw_strand(0, 0)
         sb.to(10)
         sb.cross(1)
         sb.update_to(5)
@@ -313,7 +313,7 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__call_to_then_update_to_legally(self) -> None:
         design = self.design_6helix
-        sb = design.strand(0, 0)
+        sb = design.draw_strand(0, 0)
         sb.to(10)
         sb.cross(1)
         sb.to(5)
@@ -333,14 +333,14 @@ class TestCreateStrandChainedMethods(unittest.TestCase):
 
     def test_strand__call_to_twice_increase_decrease_forward(self) -> None:
         design = self.design_6helix
-        sb = design.strand(0, 0)
+        sb = design.draw_strand(0, 0)
         sb.to(10)
         with self.assertRaises(sc.IllegalDesignError):
             sb.to(5)
 
     def test_strand__call_to_twice_decrease_increase_reverse(self) -> None:
         design = self.design_6helix
-        sb = design.strand(0, 10)
+        sb = design.draw_strand(0, 10)
         sb.to(0)
         with self.assertRaises(sc.IllegalDesignError):
             sb.to(5)
@@ -380,8 +380,8 @@ class TestModifications(unittest.TestCase):
         helices = [sc.Helix(max_offset=100)]
         design: sc.Design = sc.Design(helices=helices, strands=[], grid=sc.square)
         name = 'mod_name'
-        design.strand(0, 0).move(5).with_modification_5p(sc.Modification5Prime(display_text=name, id=name))
-        design.strand(0, 5).move(5).with_modification_3p(
+        design.draw_strand(0, 0).move(5).with_modification_5p(sc.Modification5Prime(display_text=name, id=name))
+        design.draw_strand(0, 5).move(5).with_modification_3p(
             sc.Modification3Prime(display_text=name, id=name + '3'))
         design.to_json(True)
 
@@ -389,8 +389,8 @@ class TestModifications(unittest.TestCase):
         helices = [sc.Helix(max_offset=100)]
         design: sc.Design = sc.Design(helices=helices, strands=[], grid=sc.square)
         name = 'mod_name'
-        design.strand(0, 0).move(5).with_modification_5p(sc.Modification5Prime(display_text=name, id=name))
-        design.strand(0, 5).move(5).with_modification_3p(sc.Modification3Prime(display_text=name, id=name))
+        design.draw_strand(0, 0).move(5).with_modification_5p(sc.Modification5Prime(display_text=name, id=name))
+        design.draw_strand(0, 5).move(5).with_modification_3p(sc.Modification3Prime(display_text=name, id=name))
         with self.assertRaises(sc.IllegalDesignError):
             design.to_json(True)
 
@@ -801,33 +801,33 @@ col major top-left domain start: ABCDEFLHJGIKMNOPQR
         self.design_6h: sc.Design = sc.Design(helices=helices, strands=[], grid=sc.square)
         d = self.design_6h
 
-        d.strand(1, 0).move(16).cross(0).move(-16).with_name('A')
-        d.strand(3, 0).move(16).cross(2).move(-16).with_name('B')
-        d.strand(5, 0).move(16).cross(4).move(-16).with_name('C')
+        d.draw_strand(1, 0).move(16).cross(0).move(-16).with_name('A')
+        d.draw_strand(3, 0).move(16).cross(2).move(-16).with_name('B')
+        d.draw_strand(5, 0).move(16).cross(4).move(-16).with_name('C')
 
-        d.strand(0, 40).move(-24).cross(1).move(8).with_name('D')
+        d.draw_strand(0, 40).move(-24).cross(1).move(8).with_name('D')
 
-        d.strand(1, 24).move(8).cross(2).move(-16).cross(3).move(8).with_name('E')
-        d.strand(3, 24).move(8).cross(4).move(-16).cross(5).move(8).with_name('F')
+        d.draw_strand(1, 24).move(8).cross(2).move(-16).cross(3).move(8).with_name('E')
+        d.draw_strand(3, 24).move(8).cross(4).move(-16).cross(5).move(8).with_name('F')
 
-        d.strand(0, 72).move(-32).with_name('G')
+        d.draw_strand(0, 72).move(-32).with_name('G')
 
-        d.strand(2, 40).move(-8).cross(1).move(24).with_name('H')
-        d.strand(1, 56).move(8).cross(2).move(-24).with_name('I')
+        d.draw_strand(2, 40).move(-8).cross(1).move(24).with_name('H')
+        d.draw_strand(1, 56).move(8).cross(2).move(-24).with_name('I')
 
-        d.strand(4, 40).move(-8).cross(3).move(24).with_name('J')
-        d.strand(3, 56).move(8).cross(4).move(-24).with_name('K')
+        d.draw_strand(4, 40).move(-8).cross(3).move(24).with_name('J')
+        d.draw_strand(3, 56).move(8).cross(4).move(-24).with_name('K')
 
-        d.strand(5, 24).move(32).with_name('L')
+        d.draw_strand(5, 24).move(32).with_name('L')
 
-        d.strand(2, 72).move(-8).cross(1).move(16).cross(0).move(-8).with_name('M')
-        d.strand(4, 72).move(-8).cross(3).move(16).cross(2).move(-8).with_name('N')
+        d.draw_strand(2, 72).move(-8).cross(1).move(16).cross(0).move(-8).with_name('M')
+        d.draw_strand(4, 72).move(-8).cross(3).move(16).cross(2).move(-8).with_name('N')
 
-        d.strand(5, 56).move(24).cross(4).move(-8).with_name('O')
+        d.draw_strand(5, 56).move(24).cross(4).move(-8).with_name('O')
 
-        d.strand(0, 96).move(-16).cross(1).move(16).with_name('P')
-        d.strand(2, 96).move(-16).cross(3).move(16).with_name('Q')
-        d.strand(4, 96).move(-16).cross(5).move(16).with_name('R')
+        d.draw_strand(0, 96).move(-16).cross(1).move(16).with_name('P')
+        d.draw_strand(2, 96).move(-16).cross(3).move(16).with_name('Q')
+        d.draw_strand(4, 96).move(-16).cross(5).move(16).with_name('R')
 
         for strand in d.strands:
             d.assign_dna(strand, 'A' * 32, assign_complement=False)
@@ -977,7 +977,7 @@ col major top-left domain start: ABCDEFLHJGIKMNOPQR
             helices = [sc.Helix(max_offset=100) for _ in range(1)]
             design = sc.Design(helices=helices, strands=[], grid=sc.square)
             for strand_idx in range(3 * plate_type.num_wells_per_plate() + 10):
-                design.strand(0, strand_len * strand_idx).move(strand_len).with_name(f's{strand_idx}')
+                design.draw_strand(0, strand_len * strand_idx).move(strand_len).with_name(f's{strand_idx}')
                 design.strands[-1].set_dna_sequence('T' * strand_len)
 
             design.write_idt_plate_excel_file(filename=filename, plate_type=plate_type)
@@ -1219,7 +1219,7 @@ class TestExportCadnanoV2(unittest.TestCase):
         helices = [sc.Helix(max_offset=24) for _ in range(2)]
         design = sc.Design(helices=helices, grid=sc.square)
 
-        design.strand(1, 0).move(8).cross(0).move(-8).as_circular()
+        design.draw_strand(1, 0).move(8).cross(0).move(-8).as_circular()
         # To help with debugging, uncomment these lines to write out the
         # scadnano and/or cadnano file
         #
@@ -2049,15 +2049,15 @@ class TestNickLigateAndCrossover(unittest.TestCase):
         small_nicked_helices = [sc.Helix(max_offset=100) for _ in range(2)]
         self.small_nicked_design = sc.Design(helices=small_nicked_helices, grid=sc.square)
         # forward strands
-        self.small_nicked_design.strand(0, 0).move(8)
-        self.small_nicked_design.strand(0, 8).move(8)
-        self.small_nicked_design.strand(1, 0).move(8)
-        self.small_nicked_design.strand(1, 8).move(8)
+        self.small_nicked_design.draw_strand(0, 0).move(8)
+        self.small_nicked_design.draw_strand(0, 8).move(8)
+        self.small_nicked_design.draw_strand(1, 0).move(8)
+        self.small_nicked_design.draw_strand(1, 8).move(8)
         # reverse strands
-        self.small_nicked_design.strand(0, 8).move(-8)
-        self.small_nicked_design.strand(0, 16).move(-8)
-        self.small_nicked_design.strand(1, 8).move(-8)
-        self.small_nicked_design.strand(1, 16).move(-8)
+        self.small_nicked_design.draw_strand(0, 8).move(-8)
+        self.small_nicked_design.draw_strand(0, 16).move(-8)
+        self.small_nicked_design.draw_strand(1, 8).move(-8)
+        self.small_nicked_design.draw_strand(1, 16).move(-8)
 
         self.small_nicked_design.assign_dna(self.small_nicked_design.strands[0], "ACGTACGA")
         self.small_nicked_design.assign_dna(self.small_nicked_design.strands[1], "AACCGGTA")
@@ -2078,8 +2078,8 @@ class TestNickLigateAndCrossover(unittest.TestCase):
         self.origami: sc.Design = sc.Design(strands=scafs + staps, grid=sc.square)
 
         self.two_strand_design = sc.Design(helices=[sc.Helix(max_offset=100) for _ in range(2)])
-        self.two_strand_design.strand(0, 0).move(16)
-        self.two_strand_design.strand(1, 16).move(-16)
+        self.two_strand_design.draw_strand(0, 0).move(16)
+        self.two_strand_design.draw_strand(1, 16).move(-16)
 
     def test_add_nick__twice_on_same_domain(self) -> None:
         """
@@ -2112,9 +2112,9 @@ class TestNickLigateAndCrossover(unittest.TestCase):
     0   [------- -------- ------->
         """
         design = sc.Design(helices=[sc.Helix(max_offset=24)], grid=sc.square)
-        design.strand(0, 0).move(8)
-        design.strand(0, 8).move(8)
-        design.strand(0, 16).move(8)
+        design.draw_strand(0, 0).move(8)
+        design.draw_strand(0, 8).move(8)
+        design.draw_strand(0, 16).move(8)
         design.ligate(helix=0, offset=8, forward=True)
         design.ligate(helix=0, offset=16, forward=True)
         self.assertEqual(1, len(design.strands))
@@ -4494,7 +4494,7 @@ class TestInsertRemoveDomains(unittest.TestCase):
     def setUp(self) -> None:
         helices = [sc.Helix(max_offset=100) for _ in range(4)]
         self.design = sc.Design(helices=helices, strands=[])
-        self.design.strand(0, 0).to(3).cross(1).to(0).cross(2).to(3).with_sequence('ACA TCT GTG')
+        self.design.draw_strand(0, 0).to(3).cross(1).to(0).cross(2).to(3).with_sequence('ACA TCT GTG')
         self.strand = self.design.strands[0]
 
     def test_3_helix_before_design(self) -> None:
@@ -4508,7 +4508,7 @@ class TestInsertRemoveDomains(unittest.TestCase):
     def test_insert_domain_with_sequence(self) -> None:
         helices = [sc.Helix(max_offset=100) for _ in range(4)]
         design = sc.Design(helices=helices, strands=[])
-        design.strand(0, 0).to(3).cross(1).to(0).cross(3).to(3).with_sequence('ACA TCT GTG')
+        design.draw_strand(0, 0).to(3).cross(1).to(0).cross(3).to(3).with_sequence('ACA TCT GTG')
         strand = design.strands[0]
 
         expected_strand_before = sc.Strand([
@@ -4572,7 +4572,7 @@ class TestLabels(unittest.TestCase):
 
     def test_with_label__str(self) -> None:
         label = 'abc'
-        self.design.strand(0, 0).to(5).cross(1).to(0).with_label(label)
+        self.design.draw_strand(0, 0).to(5).cross(1).to(0).with_label(label)
         actual_strand = self.design.strands[0]
         expected_strand = sc.Strand(domains=[
             sc.Domain(0, True, 0, 5),
@@ -4583,7 +4583,7 @@ class TestLabels(unittest.TestCase):
 
     def test_with_label__dict(self) -> None:
         label = {'name': 'abc', 'type': 3}
-        self.design.strand(0, 0).to(5).cross(1).to(0).with_label(label)
+        self.design.draw_strand(0, 0).to(5).cross(1).to(0).with_label(label)
         actual_strand = self.design.strands[0]
         expected_strand = sc.Strand(domains=[
             sc.Domain(0, True, 0, 5),
@@ -4595,7 +4595,7 @@ class TestLabels(unittest.TestCase):
     def test_with_domain_label(self) -> None:
         label0: Union[str, Dict[str, Any]] = 'abc'
         label1: Union[str, Dict[str, Any]] = {'name': 'abc', 'type': 3}
-        self.design.strand(0, 0).to(5).with_domain_label(label0).cross(1).to(0).with_domain_label(label1)
+        self.design.draw_strand(0, 0).to(5).with_domain_label(label0).cross(1).to(0).with_domain_label(label1)
         actual_strand = self.design.strands[0]
         expected_strand = sc.Strand(domains=[
             sc.Domain(0, True, 0, 5, label=label0),
@@ -4609,7 +4609,7 @@ class TestLabels(unittest.TestCase):
         strand_label = 'xyz'
         label0: Union[str, Dict[str, Any]] = 'abc'
         label1: Union[str, Dict[str, Any]] = {'name': 'abc', 'type': 3}
-        self.design.strand(0, 0).to(5).with_domain_label(label0).cross(1).to(0).with_domain_label(label1) \
+        self.design.draw_strand(0, 0).to(5).with_domain_label(label0).cross(1).to(0).with_domain_label(label1) \
             .with_label(strand_label)
         actual_strand = self.design.strands[0]
         expected_strand = sc.Strand(domains=[
@@ -4635,7 +4635,7 @@ class TestCircularStrandsLegalMods(unittest.TestCase):
     def setUp(self) -> None:
         helices = [sc.Helix(max_offset=10) for _ in range(2)]
         self.design = sc.Design(helices=helices, strands=[])
-        self.design.strand(0, 0).move(10).cross(1).move(-10)
+        self.design.draw_strand(0, 0).move(10).cross(1).move(-10)
         self.strand = self.design.strands[0]
         r'''
         0  [--------\
@@ -4679,12 +4679,12 @@ class TestCircularStrandEdits(unittest.TestCase):
     def setUp(self) -> None:
         helices = [sc.Helix(max_offset=10) for _ in range(3)]
         self.design = sc.Design(helices=helices, strands=[])
-        self.design.strand(0, 0).move(10).cross(1).move(-10)
-        self.design.strand(0, 15).move(5).cross(1).move(-10).cross(0).move(5)
-        self.design.strand(0, 20).move(10)
-        self.design.strand(1, 30).move(-10)
-        self.design.strand(0, 30).move(10).loopout(1, 5).move(-10).cross(2).move(10).as_circular()
-        self.design.strand(0, 40).move(10).cross(1).move(-10).as_circular()
+        self.design.draw_strand(0, 0).move(10).cross(1).move(-10)
+        self.design.draw_strand(0, 15).move(5).cross(1).move(-10).cross(0).move(5)
+        self.design.draw_strand(0, 20).move(10)
+        self.design.draw_strand(1, 30).move(-10)
+        self.design.draw_strand(0, 30).move(10).loopout(1, 5).move(-10).cross(2).move(10).as_circular()
+        self.design.draw_strand(0, 40).move(10).cross(1).move(-10).as_circular()
         self.num_strands = len(self.design.strands)
         r'''
            0          10         20         30         40
@@ -5553,8 +5553,8 @@ class TestAssignDNA(unittest.TestCase):
             <-------I: 3-------]
         """
         design = sc.Design(grid=sc.square, helices=[sc.Helix(max_offset=100)], strands=[])
-        design.strand(0, 0).move(16)
-        design.strand(0, 16).move(-16)
+        design.draw_strand(0, 0).move(16)
+        design.draw_strand(0, 16).move(-16)
         design.add_insertion(0, 8, 3)
         design.assign_dna(strand=design.strands[0], sequence='AACGTATCGCGATGCATCC', assign_complement=True)
 
@@ -5577,9 +5577,9 @@ class TestAssignDNA(unittest.TestCase):
             TTGCATAGCGCTACGTAGG
         """
         design = sc.Design(grid=sc.square, helices=[sc.Helix(max_offset=100)], strands=[])
-        design.strand(0, 0).move(16)
-        design.strand(0, 5).move(-5)
-        design.strand(0, 16).move(-11)
+        design.draw_strand(0, 0).move(16)
+        design.draw_strand(0, 5).move(-5)
+        design.draw_strand(0, 16).move(-11)
         design.add_insertion(0, 8, 3)
         design.assign_dna(strand=design.strands[1], sequence='ACGTT', assign_complement=True)
         design.assign_dna(strand=design.strands[2], sequence='GGATGCATCGCGAT', assign_complement=True)
@@ -5603,8 +5603,8 @@ class TestAssignDNA(unittest.TestCase):
             <-------X------]
         """
         design = sc.Design(grid=sc.square, helices=[sc.Helix(max_offset=100)], strands=[])
-        design.strand(0, 0).move(16)
-        design.strand(0, 16).move(-16)
+        design.draw_strand(0, 0).move(16)
+        design.draw_strand(0, 16).move(-16)
         design.add_deletion(0, 8)
         design.assign_dna(strand=design.strands[0], sequence='AACGTACGTGCATCC', assign_complement=True)
 
@@ -5626,9 +5626,9 @@ class TestAssignDNA(unittest.TestCase):
             TTGCATAG GCTACGT
         """
         design = sc.Design(grid=sc.square, helices=[sc.Helix(max_offset=100)], strands=[])
-        design.strand(0, 0).move(16)
-        design.strand(0, 5).move(-5)
-        design.strand(0, 16).move(-11)
+        design.draw_strand(0, 0).move(16)
+        design.draw_strand(0, 5).move(-5)
+        design.draw_strand(0, 16).move(-11)
         design.add_deletion(0, 8)
         design.assign_dna(strand=design.strands[1], sequence='ACGTT', assign_complement=True)
         design.assign_dna(strand=design.strands[2], sequence='TGCATCGGAT', assign_complement=True)
@@ -5831,7 +5831,7 @@ class TestAssignDNAToDomains(unittest.TestCase):
         <???---???---???---???---???---???---???-
          098   765   432   109   876   543   210
         """
-        design.strand(0, 21).to(0)
+        design.draw_strand(0, 21).to(0)
         self.assertEqual(1, len(design.strands))
         self.assertEqual(21, design.strands[0].domains[0].dna_length())
 
@@ -5842,7 +5842,7 @@ class TestAssignDNAToDomains(unittest.TestCase):
         <???---???---???---???---ACG---???---???-
          098   765   432   109   876   543   210
         """
-        design.strand(0, 12).to(15).with_sequence('TGC')
+        design.draw_strand(0, 12).to(15).with_sequence('TGC')
         self.assertEqual('TGC'.replace(' ', ''), design.strands[-1].dna_sequence)
         self.assertEqual('??? ??? GCA ??? ??? ??? ???'.replace(' ', ''), design.strands[0].dna_sequence)
 
@@ -5853,7 +5853,7 @@ class TestAssignDNAToDomains(unittest.TestCase):
         <???---???---???---???---ACG---???---???-
          098   765   432   109   876   543   210
         """
-        design.strand(0, 0).to(3).with_sequence('ACG', assign_complement=False)
+        design.draw_strand(0, 0).to(3).with_sequence('ACG', assign_complement=False)
         self.assertEqual('ACG'.replace(' ', ''), design.strands[-1].dna_sequence)
         self.assertEqual('??? ??? GCA ??? ??? ??? ???'.replace(' ', ''), design.strands[0].dna_sequence)
 
@@ -5867,7 +5867,7 @@ class TestAssignDNAToDomains(unittest.TestCase):
         <???---AAG---???---TTG---ACG---???---???-
          098   765   432   109   876   543   210
         """
-        sb = design.strand(0, 9).to(12)
+        sb = design.draw_strand(0, 9).to(12)
         sb.with_domain_sequence('AAC')
         sb.cross(0, offset=3)
         sb.to(6)
@@ -5885,7 +5885,7 @@ class TestAssignDNAToDomains(unittest.TestCase):
         <???---AAG---CCT---TTG---ACG---AAC---CGT-
          098   765   432   109   876   543   210
         """
-        design.strand(0, 6).to(9) \
+        design.draw_strand(0, 6).to(9) \
             .with_domain_sequence('GGA') \
             .cross(0, offset=15) \
             .to(18) \
@@ -6112,8 +6112,8 @@ class TestOxdnaExport(unittest.TestCase):
         """
         helices = [sc.Helix(max_offset=7), sc.Helix(max_offset=7)]
         design = sc.Design(helices=helices, grid=sc.square)
-        design.strand(0, 0).move(7).cross(1).move(-7)
-        design.strand(0, 7).move(-7).cross(1).move(7)
+        design.draw_strand(0, 0).move(7).cross(1).move(-7)
+        design.draw_strand(0, 7).move(-7).cross(1).move(7)
 
         # expected values for verification
         expected_num_nucleotides = 7 * 4
@@ -6243,8 +6243,8 @@ class TestOxdnaExport(unittest.TestCase):
             'b': sc.HelixGroup(position=sc.Position3D(100, 0, 0), grid=sc.square),
         }
         design = sc.Design(helices=helices, groups=groups)
-        design.strand(0, 0).move(7).cross(1).move(-7)
-        design.strand(2, 7).move(-7).cross(3).move(7) # unlike basic design, put strand on helices 2,3
+        design.draw_strand(0, 0).move(7).cross(1).move(-7)
+        design.draw_strand(2, 7).move(-7).cross(3).move(7) # unlike basic design, put strand on helices 2,3
 
         # expected values for verification
         expected_num_nucleotides = 7 * 4
@@ -6361,7 +6361,7 @@ class TestOxdnaExport(unittest.TestCase):
         helices = [sc.Helix(grid_position=(1, 1), max_offset=8), sc.Helix(grid_position=(0, 1), max_offset=8),
                    sc.Helix(grid_position=(0, 2), max_offset=8)]
         design = sc.Design(helices=helices, grid=sc.honeycomb)
-        design.strand(0, 0).to(8).cross(1).move(-8).cross(2).to(8)
+        design.draw_strand(0, 0).to(8).cross(1).move(-8).cross(2).to(8)
 
         # expected values for verification
         expected_num_nucleotides = 8 * 3
@@ -6458,7 +6458,7 @@ class TestOxdnaExport(unittest.TestCase):
         """
         helix = [sc.Helix(max_offset=7)]
         design = sc.Design(helices=helix, grid=sc.square)
-        design.strand(0, 0).to(7)
+        design.draw_strand(0, 0).to(7)
         design.add_deletion(helix=0, offset=4)
 
         # expected values for verification
@@ -6550,7 +6550,7 @@ class TestOxdnaExport(unittest.TestCase):
         """
         helix = [sc.Helix(max_offset=10)]
         design = sc.Design(helices=helix, grid=sc.square)
-        design.strand(0, 0).to(7)
+        design.draw_strand(0, 0).to(7)
         design.add_insertion(helix=0, offset=4, length=1)
 
         # expected values for verification
@@ -6643,8 +6643,8 @@ class TestOxdnaExport(unittest.TestCase):
         """
         helix = [sc.Helix(max_offset=14)]
         design = sc.Design(helices=helix, grid=sc.square)
-        design.strand(0, 0).to(4).loopout(0, 4).to(7)
-        design.strand(0, 7).to(0)
+        design.draw_strand(0, 0).to(4).loopout(0, 4).to(7)
+        design.draw_strand(0, 7).to(0)
 
         # expected values for verification
         expected_num_nucleotides = 7 * 2 + 4

--- a/tutorial/tutorial.md
+++ b/tutorial/tutorial.md
@@ -220,8 +220,7 @@ We do this by creating a "precursor" design, which is not the final design, and 
 
 The scaffold is a good starting point. It is one long strand, but we won't specify it as such. Instead, we will specify it by drawing one strand on each helix, spanning the full length, and then modifying these strands with crossovers, eventually joining them into one long strand.
 
-We can use the function [Design.strand](https://scadnano-python-package.readthedocs.io/en/latest/#scadnano.Design.strand) to draw strands. It takes two integer arguments: a helix and an offset, and uses "chained method calls" to give a short syntax for specifying strands. In this case, depending on the helix, we either want the strand (in order from 5' end to 3' end) to start at offset 0 and move forward (right) by 288, or start at offset 288 and move in reverse by 288 (i.e., move by -288). The bottommost helix, 23, is an exception, where we want the "nick" to be, so we actually want to draw two strands, with a break between them at the halfway point 144:
-
+We can use the function [Design.draw_strand](https://scadnano-python-package.readthedocs.io/en/latest/#scadnano.Design.draw_strand) to draw strands. It takes two integer arguments: a helix and an offset, and uses "chained method calls" to give a short syntax for specifying strands. In this case, depending on the helix, we either want the strand (in order from 5' end to 3' end) to start at offset 0 and move forward (right) by 288, or start at offset 288 and move in reverse by 288 (i.e., move by -288). The bottommost helix, 23, is an exception, where we want the "nick" to be, so we actually want to draw two strands, with a break between them at the halfway point 144:
 
 ```python
 def create_design() -> sc.Design:
@@ -235,11 +234,11 @@ def create_design() -> sc.Design:
 
 def add_scaffold_precursors(design: sc.Design) -> None:
     for helix in range(0, 23, 2):  # scaffold goes forward on even helices
-        design.strand(helix, 0).move(288).as_scaffold()
+        design.draw_strand(helix, 0).move(288).as_scaffold()
     for helix in range(1, 23, 2):  # scaffold goes reverse on odd helices
-        design.strand(helix, 288).move(-288).as_scaffold()
-    design.strand(23, 288).move(-144).as_scaffold()  # bottom part of scaffold has a "nick"
-    design.strand(23, 144).move(-144).as_scaffold()  #
+        design.draw_strand(helix, 288).move(-288).as_scaffold()
+    design.draw_strand(23, 288).move(-144).as_scaffold()  # bottom part of scaffold has a "nick"
+    design.draw_strand(23, 144).move(-144).as_scaffold()  #
 ```
 
 We drew the scaffold precursor on helix 23 as two strands, each half the length (144) of those on other helices (288).
@@ -615,11 +614,11 @@ def create_design() -> sc.Design:
 
 def add_scaffold_precursors(design: sc.Design) -> None:
     for helix in range(0, 23, 2):  # scaffold goes forward on even helices
-        design.strand(helix, 0).move(288).as_scaffold()
+        design.draw_strand(helix, 0).move(288).as_scaffold()
     for helix in range(1, 23, 2):  # scaffold goes reverse on odd helices
-        design.strand(helix, 288).move(-288).as_scaffold()
-    design.strand(23, 288).move(-144).as_scaffold()  # bottom part of scaffold has a "nick"
-    design.strand(23, 144).move(-144).as_scaffold()  #
+        design.draw_strand(helix, 288).move(-288).as_scaffold()
+    design.draw_strand(23, 288).move(-144).as_scaffold()  # bottom part of scaffold has a "nick"
+    design.draw_strand(23, 144).move(-144).as_scaffold()  #
 
 
 def add_scaffold_crossovers(design: sc.Design) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed the method `Design.strand` to `Design.draw_strand`, and added a printed warning about deprecation to the old method `Design.strand`, before it simply calls `Design.draw_strand`.

## Related Issue
#219 

## Motivation and Context
The method `Design.strand` was poorly named. `Design.draw_strand` better describes what it does.

## How Has This Been Tested?
All unit tests pass.

