### PR TITLE
Set Position3D as frozen

### DIFF
--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -1044,7 +1044,7 @@ class ModificationInternal(Modification):
 ##########################################################################
 
 
-@dataclass
+@dataclass(frozen=True)
 class Position3D(_JSONSerializable):
     """
     Position (x,y,z) in 3D space.


### PR DESCRIPTION
Mutable defaults in dataclasses will cause an error in Python 3.11.  HelixGroup has a Position3D default.  Position3D appears to be intended to be immutable, and is never used mutably in the code, but does not have `frozen=True` set for the dataclass options.  This sets it, and causes tests to pass with Python 3.11.0b4.

Alternatively, Position3D could be left as is, and the HelixGroup position could be made to be `position: Position3D = field(default_factory=lambda: Position3D(x=0,y=0,z=0))`, but this seems less efficient.