### PR TITLE
Add filename extensions to oxDNA exports with filename_no_extension set.

### DIFF
--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -6994,8 +6994,8 @@ class Design(_JSONSerializable, Generic[StrandLabel, DomainLabel]):
         """
         dat, top = self.to_oxdna_format(warn_duplicate_strand_names)
 
-        write_file_same_name_as_running_python_script(dat, 'dat', directory, filename_no_extension)
-        write_file_same_name_as_running_python_script(top, 'top', directory, filename_no_extension)
+        write_file_same_name_as_running_python_script(dat, 'dat', directory, filename_no_extension, add_extension=True)
+        write_file_same_name_as_running_python_script(top, 'top', directory, filename_no_extension, add_extension=True)
 
     # @_docstring_parameter was used to substitute sc in for the filename extension, but it is
     # incompatible with .. code-block:: and caused a very strange and hard-to-determine error,
@@ -7722,7 +7722,7 @@ def _name_of_this_script() -> str:
 
 
 def write_file_same_name_as_running_python_script(contents: str, extension: str, directory: str = '.',
-                                                  filename: Optional[str] = None) -> None:
+                                                  filename: Optional[str] = None, add_extension: bool = False) -> None:
     """
     Writes a text file with `contents` whose name is (by default) the same as the name of the
     currently running script, but with extension ``.py`` changed to `extension`.
@@ -7736,16 +7736,18 @@ def write_file_same_name_as_running_python_script(contents: str, extension: str,
     :param filename:
         filename to use instead of the currently running script
     """
-    relative_filename = _get_filename_same_name_as_running_python_script(directory, extension, filename)
+    relative_filename = _get_filename_same_name_as_running_python_script(directory, extension, filename, add_extension=add_extension)
     with open(relative_filename, 'w') as out_file:
         out_file.write(contents)
 
 
 def _get_filename_same_name_as_running_python_script(directory: str, extension: str,
-                                                     filename: Optional[str]) -> str:
+                                                     filename: Optional[str], add_extension: bool = False) -> str:
     # if filename is not None, assume it has an extension
     if filename is None:
         filename = _name_of_this_script() + '.' + extension
+    elif add_extension:
+        filename += '.' + extension
     relative_filename = _create_directory_and_set_filename(directory, filename)
     return relative_filename
 

--- a/tests/scadnano_tests.py
+++ b/tests/scadnano_tests.py
@@ -1,5 +1,7 @@
 import dataclasses
 import os
+import sys
+import tempfile
 import unittest
 import re
 import json
@@ -7556,6 +7558,27 @@ class TestOxdnaExport(unittest.TestCase):
 
             self.assertAlmostEqual(self.EXPECTED_ADJ_NUC_CM_DIST2, sqr_dist2)
 
+    def test_file_output(self) -> None:
+        # Arbitrary design
+        helix = [sc.Helix(max_offset=14)]
+        design = sc.Design(helices=helix, grid=sc.square)
+        design.draw_strand(0, 0).to(4).loopout(0, 4).to(7)
+        design.draw_strand(0, 7).to(0)
+
+        scriptname = os.path.basename(sys.argv[0])[:-3]
+
+        dat, top = design.to_oxdna_format()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # First, write to the directory, in which case the names should be the script name
+            design.write_oxdna_files(directory=tmpdir)
+            self.assertEqual(top, open(tmpdir + '/' + scriptname + '.top').read())
+            self.assertEqual(dat, open(tmpdir + '/' + scriptname + '.dat').read())
+
+            # Now, write, to a specific filename without extensions
+            design.write_oxdna_files(directory=tmpdir, filename_no_extension='oxdna-Export with spaces in name')
+            self.assertEqual(top, open(tmpdir + '/oxdna-Export with spaces in name.top').read())
+            self.assertEqual(dat, open(tmpdir + '/oxdna-Export with spaces in name.dat').read())
 
 class TestPlateMaps(unittest.TestCase):
 


### PR DESCRIPTION
Closes #245.