### PR TITLE
234 export newer excel file format

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -8,21 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [ 3.7, 3.8, 3.9, "3.10", "3.11" ]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Setup conda
-      uses: s-weigand/setup-conda@v1
-      with:
-        activate-conda: true
-    - name: Install xlwt, xlrd, tabulate with conda
-      run: conda install xlwt=1.3.0 xlrd=2.0.1 tabulate=0.8.9
-    - name: Install docutils with conda
-      run: conda install docutils=0.16
-    - name: Test with unittest
-      run: python -m unittest -v tests/scadnano_tests.py
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Setup conda
+        uses: s-weigand/setup-conda@v1
+        with:
+          activate-conda: true
+      - name: Install xlwt, xlrd, tabulate with conda
+        run: conda install openpyxl=3.1.2 tabulate=0.9.0
+      - name: Install docutils with conda
+        run: conda install docutils=0.16
+      - name: Test with unittest
+        run: python -m unittest -v tests/scadnano_tests.py

--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -53,7 +53,7 @@ so the user must take care not to set them.
 # needed to use forward annotations: https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep563
 from __future__ import annotations
 
-__version__ = "0.18.0"  # version line; WARNING: do not remove or change this line or comment
+__version__ = "0.18.1"  # version line; WARNING: do not remove or change this line or comment
 
 import collections
 import dataclasses

--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -7208,8 +7208,8 @@ class Design(_JSONSerializable):
 
     @staticmethod
     def _setup_excel_file(directory: str, filename: Optional[str]) -> Tuple[str, Any]:
-        import xlwt  # type: ignore
-        plate_extension = f'xls'
+        import openpyxl  # type: ignore
+        plate_extension = f'xlsx'
         if filename is None:
             filename_plate = _get_filename_same_name_as_running_python_script(
                 directory, plate_extension, filename)

--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,9 @@ setup(name='scadnano',
       url="https://github.com/UC-Davis-molecular-computing/scadnano-python-package",
       long_description=long_description,
       long_description_content_type='text/markdown; variant=GFM',
-      python_requires='>=3.6',
+      python_requires='>=3.7',
       install_requires=[
-        'xlwt',
-        'dataclasses>=0.6; python_version < "3.7"',
-        'tabulate',
+          'openpyxl',
+          'tabulate',
       ],
-      tests_require=['xlrd'],
-)
+      )

--- a/tests/scadnano_tests.py
+++ b/tests/scadnano_tests.py
@@ -8,7 +8,7 @@ import json
 import math
 from typing import Iterable, Union, Dict, Any
 
-import xlrd  # type: ignore
+import openpyxl  # type: ignore
 
 import scadnano as sc
 import scadnano.origami_rectangle as rect


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removing xlwt and xlrd as dependencies, adding openpyxl.

## Related Issue
#234 

## Motivation and Context
The old packages were needed when IDT did not support the newer Excel format. Now they do so we use a more modern library that reads/writes the modern Excel format.


