### PR TITLE
Changed to use mamba

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,4 +3,5 @@ name: scadnano-test
 channels:
   - defaults
 dependencies:
+  - python=3.7
   - xlwt=1.3.0=py37_0

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -26,4 +26,4 @@ conda:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.7"
+    python: "mambaforge-22.9"


### PR DESCRIPTION
In ``build.tools.python`` in readthedocs.yml, I changed the value to mambaforge. According to the docs, https://docs.readthedocs.io/en/stable/config-file/v2.html#conda, it says it's

> it’s required to specify build.tools.python to tell Read the Docs to use whether Conda or Mamba to create the environment.

Which could be the cause of the build error. I moved ``python=3.7`` to ``environment.yml`` instead. 
