### PR TITLE
Added pip packages to enviornment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,3 +5,8 @@ channels:
 dependencies:
   - python=3.7
   - xlwt=1.3.0=py37_0
+  - pip
+  - pip:
+    - sphinx
+    - sphinx_rtd_theme
+    - openpyxl


### PR DESCRIPTION
The last pull request failed but for a completely different issue now so hopefully we are still moving forward.

The issue now is that it appears to be that some packages aren't installed when we push to readthedocs.org.
In the Github action, I saw that it runs ``pip install sphinx sphinx_rtd_theme openpyxl`` before building. However, I found that nowhere else does it specify to install these packages when publishing to readthedocs.org, so I added the requirements to ``environment.yml``.