### PR TITLE
Dev

### DIFF
--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -7755,6 +7755,25 @@ class Design(_JSONSerializable):
 
         workbook.save(filename_plate)
 
+    def write_oxview_file(self, directory: str = '.', filename: Optional[str] = None,
+                          warn_duplicate_strand_names: bool = True, use_strand_colors: bool = True) -> None:
+        """Writes an oxView file rerpesenting this design.
+
+        :param directory:
+            directy in which to write the file (default: current working directory)
+        :param filename:
+            name of the file to write (default: name of the running script with .oxview extension)
+        :param warn_duplicate_strand_names:
+            if True, prints a warning to the screen indicating when strands are found to
+            have duplicate names. (default: True)
+        :param use_strand_colors:
+            if True (default), sets the color of each nucleotide in a strand in oxView to the color
+            of the strand.
+        """
+        text = self.to_oxview_format(warn_duplicate_strand_names=warn_duplicate_strand_names,
+                                     use_strand_colors=use_strand_colors)
+        write_file_same_name_as_running_python_script(text, 'oxview', directory, filename)
+
     def to_oxview_format(self, warn_duplicate_strand_names: bool = True,
                          use_strand_colors: bool = True) -> str:
         """
@@ -7768,6 +7787,25 @@ class Design(_JSONSerializable):
             of the strand.
         :return:
             string in oxView text format
+        """
+        oxvsystem = self.to_oxview_json(warn_duplicate_strand_names=warn_duplicate_strand_names,
+                                        use_strand_colors=use_strand_colors)
+        text = json.dumps(oxvsystem)
+        return text
+
+    def to_oxview_json(self, warn_duplicate_strand_names: bool = True,
+                       use_strand_colors: bool = True) -> dict:
+        """
+        Exports to oxView format: https://github.com/sulcgroup/oxdna-viewer/blob/master/file-format.md
+
+        :param warn_duplicate_strand_names:
+            if True, prints a warning to the screen indicating when strands are found to
+            have duplicate names. (default: True)
+        :param use_strand_colors:
+            if True (default), sets the color of each nucleotide in a strand in oxView to the color
+            of the strand.
+        :return:
+            Python dict
         """
         import datetime
         self._check_legal_design(warn_duplicate_strand_names)
@@ -7859,27 +7897,7 @@ class Design(_JSONSerializable):
                      'systems': [{'id': 0, 'strands': oxview_strands}],
                      'forces': [], 'selections': []}
 
-        text = json.dumps(oxvsystem)
-        return text
-
-    def write_oxview_file(self, directory: str = '.', filename: Optional[str] = None,
-                          warn_duplicate_strand_names: bool = True, use_strand_colors: bool = True) -> None:
-        """Writes an oxView file rerpesenting this design.
-
-        :param directory:
-            directy in which to write the file (default: current working directory)
-        :param filename:
-            name of the file to write (default: name of the running script with .oxview extension)
-        :param warn_duplicate_strand_names:
-            if True, prints a warning to the screen indicating when strands are found to
-            have duplicate names. (default: True)
-        :param use_strand_colors:
-            if True (default), sets the color of each nucleotide in a strand in oxView to the color
-            of the strand.
-        """
-        oxvsystem = self.to_oxview_format(warn_duplicate_strand_names=warn_duplicate_strand_names,
-                                          use_strand_colors=use_strand_colors)
-        write_file_same_name_as_running_python_script(json.dumps(oxvsystem), 'oxview', directory, filename)
+        return oxvsystem
 
     def to_oxdna_format(self, warn_duplicate_strand_names: bool = True) -> Tuple[str, str]:
         """Exports to oxdna format.

--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -7756,9 +7756,9 @@ class Design(_JSONSerializable):
         workbook.save(filename_plate)
 
     def to_oxview_format(self, warn_duplicate_strand_names: bool = True,
-                         use_strand_colors: bool = True) -> dict:
+                         use_strand_colors: bool = True) -> str:
         """
-        Exports to oxView format.
+        Exports to oxView format: https://github.com/sulcgroup/oxdna-viewer/blob/master/file-format.md
 
         :param warn_duplicate_strand_names:
             if True, prints a warning to the screen indicating when strands are found to
@@ -7766,6 +7766,8 @@ class Design(_JSONSerializable):
         :param use_strand_colors:
             if True (default), sets the color of each nucleotide in a strand in oxView to the color
             of the strand.
+        :return:
+            string in oxView text format
         """
         import datetime
         self._check_legal_design(warn_duplicate_strand_names)
@@ -7857,7 +7859,8 @@ class Design(_JSONSerializable):
                      'systems': [{'id': 0, 'strands': oxview_strands}],
                      'forces': [], 'selections': []}
 
-        return oxvsystem
+        text = json.dumps(oxvsystem)
+        return text
 
     def write_oxview_file(self, directory: str = '.', filename: Optional[str] = None,
                           warn_duplicate_strand_names: bool = True, use_strand_colors: bool = True) -> None:

--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -54,7 +54,7 @@ so the user must take care not to set them.
 # needed to use forward annotations: https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep563
 from __future__ import annotations
 
-__version__ = "0.19.3"  # version line; WARNING: do not remove or change this line or comment
+__version__ = "0.19.4"  # version line; WARNING: do not remove or change this line or comment
 
 import collections
 import dataclasses

--- a/tests/scadnano_tests.py
+++ b/tests/scadnano_tests.py
@@ -6987,8 +6987,8 @@ class TestOxviewExport(unittest.TestCase):
 
         oxdna_system = _convert_design_to_oxdna_system(design)
 
-        oxv = design.to_oxview_format(use_strand_colors=True)
-        oxv_no_color = design.to_oxview_format(use_strand_colors=False)
+        oxv = design.to_oxview_json(use_strand_colors=True)
+        oxv_no_color = design.to_oxview_json(use_strand_colors=False)
 
         # Is the box correct?
         self.assertEqual(list(oxdna_system.compute_bounding_box()), oxv['box'])
@@ -7038,7 +7038,7 @@ class TestOxviewExport(unittest.TestCase):
         des.draw_strand(2, 20).extension_5p(8).to(12).extension_3p(8).with_sequence(
             'ATACTGGAACTACGCGCGTGAATT', assign_complement=False)
 
-        oxv = des.to_oxview_format()
+        oxv = des.to_oxview_json()
 
         strands = oxv['systems'][0]['strands']
 
@@ -7092,7 +7092,7 @@ class TestOxviewExport(unittest.TestCase):
             sc.Color(254, 123, 222))
         design.draw_strand(0, 7).move(-7).cross(1).move(7)
 
-        oxv = design.to_oxview_format(use_strand_colors=True)
+        oxv = design.to_oxview_json(use_strand_colors=True)
 
         with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
             design.write_oxview_file(filename=f.name)


### PR DESCRIPTION
# Release notes

Changed type of `Design.to_oxview_format` from `dict` to `str` to keep convention with similar other methods such as `Design.to_oxdna_format`.

This is a breaking change, although the minor version number did not change. The method `Design.to_oxview_json` has the same functionality that `Design.to_oxview_format`, namely that it returns a JSON-serializable dict. Calling `json.dumps` on this dict produces the same output as `Design.to_oxview_format`.