### PR TITLE
Debbuging cadnanov2 export of paranemic crossovers when both segments…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ tests_outputs/
 .vscode/
 dist/
 .mypy_cache/
+test_paranemic.py

--- a/tests/scadnano_tests.py
+++ b/tests/scadnano_tests.py
@@ -1629,6 +1629,19 @@ class TestExportCadnanoV2(unittest.TestCase):
         output_design = sc.Design.from_cadnano_v2(json_dict=json.loads(output_json))
         self.assertEqual(4, len(output_design.helices))
 
+    def test_paranemic_crossover_other_direction(self) -> None:
+        design = sc.Design.from_scadnano_file(
+            os.path.join(self.input_path, f'test_paranemic_crossover_other_direction.{self.ext}'))
+        # To help with debugging, uncomment these lines to write out the
+        # scadnano and/or cadnano file
+        #
+        # design.write_cadnano_v2_file(directory=self.output_path,
+        #                          filename='test_paranemic_crossover.json')
+        output_json = design.to_cadnano_v2_json()
+
+        output_design = sc.Design.from_cadnano_v2(json_dict=json.loads(output_json))
+        self.assertEqual(4, len(output_design.helices))
+
     def test_parity_issue(self) -> None:
         """ We do not design where the parity of the helix
         does not correspond to the direction.

--- a/tests_inputs/cadnano_v2_export/test_paranemic_crossover_other_direction.sc
+++ b/tests_inputs/cadnano_v2_export/test_paranemic_crossover_other_direction.sc
@@ -1,0 +1,27 @@
+{
+  "version": "0.19.4",
+  "grid": "square",
+  "helices": [
+    {"grid_position": [19, 14], "idx": 1, "max_offset": 64},
+    {"grid_position": [19, 15], "idx": 0, "max_offset": 64},
+    {"grid_position": [19, 16], "idx": 3, "max_offset": 64},
+    {"grid_position": [19, 17], "idx": 2, "max_offset": 64}
+  ],
+  "strands": [
+    {
+      "color": "#0066cc",
+      "is_scaffold": true,
+      "domains": [
+        {"helix": 3, "forward": false, "start": 8, "end": 24},
+        {"helix": 1, "forward": false, "start": 8, "end": 24}
+      ]
+    },
+    {
+      "color": "#007200",
+      "domains": [
+        {"helix": 2, "forward": false, "start": 24, "end": 50},
+        {"helix": 0, "forward": false, "start": 24, "end": 50}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
… are in the 3' direction

- Paranemic crossovers when both segments were in the 3p direction was bugged
- Added test for this case (paranemic crossovers in the 5p direction were already tested)
- Added raise ValueError when the parity of helix row is not the same for paranemic crossover as this is not valid in cadnanov2

## Description

## Related Issue

https://github.com/UC-Davis-molecular-computing/scadnano-python-package/issues/308

## Motivation and Context


## How Has This Been Tested?

- `TestExportCadnanoV2.test_paranemic_crossover_other_direction`

## Screenshots (if appropriate):

<img width="1025" alt="Capture d’écran 2024-10-17 à 13 54 34" src="https://github.com/user-attachments/assets/5731f177-94a8-4419-b047-d8130dadab2c">

