### PR TITLE
Close Issue #309: account for helix group rotation properly

### DIFF
--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -9041,7 +9041,9 @@ def _oxdna_get_helix_vectors(design: Design, helix: Helix) -> Tuple[_OxdnaVector
         position_in_helix_group = grid_position_to_position(helix.grid_position, grid, geometry)
 
     # helix's position in it's group rotated so that it exists in the global rotation
-    position_in_helix_group_rotated = (pitch_axis * position_in_helix_group.x) + (yaw_axis   * position_in_helix_group.y) + (roll_axis  * position_in_helix_group.z)
+    position_in_helix_group_rotated = ((pitch_axis * position_in_helix_group.x) +
+                                       (yaw_axis * position_in_helix_group.y) +
+                                       (roll_axis  * position_in_helix_group.z))
 
     # offset of helix group origin with respect to global coordinates
     helix_group_offset = _OxdnaVector(group.position.x, group.position.y, group.position.z)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

closes issue #309

Before this change, helix group rotation wasn't correctly applied to helices during oxDNA export
This change fixes this by applying the helix group rotation to each helix before being translated by the helix group's origin position

This change also avoids using the `Design.roll_of_helix(helix)` since this gives the cumulative roll of the helix plus the roll of the group
Now, the helix group's roll is applied to the helix to determine it's global positions while the helix's individual roll is accounted for by separately rotating the normal axis returned by `_oxdna_get_helix_vectors`

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#309 

## Screenshots:

Note the rolls of the helices as indicated by the slice bar
![image](https://github.com/user-attachments/assets/61dd899a-064c-4583-bb12-f3c5f0bf2f33)
![image](https://github.com/user-attachments/assets/cde4d9d5-4fbd-4a6f-ab6b-0ea419c92963)

These are represented in the rolls of the exported helices
![image](https://github.com/user-attachments/assets/820da115-4427-40c6-a840-028599834734)
![image](https://github.com/user-attachments/assets/a81a7b91-2dbe-44ff-a86d-b1f7fa40ddca)

