### PR TITLE
fixes #323: replace archived automated release action; add CHANGELOG.md and dev-branch issue lifecycle

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,56 @@
+name: "changelog"
+
+# Regenerates CHANGELOG.md from ALL GitHub releases and commits it directly to
+# main whenever a release is published, edited, or deleted.
+#
+# Interactions to be aware of:
+#   - release.yml creates releases with GITHUB_TOKEN, whose events do not
+#     trigger workflows, so `published` does NOT run this. CHANGELOG.md updates
+#     when a maintainer EDITS the release (replacing the placeholder title and
+#     notes) -- exactly when the notes become worth recording.
+#   - Editing a release whose tag predates this file produces NO run (release
+#     events use the workflow file at the tagged commit). Remedy: run this
+#     workflow manually via workflow_dispatch (Actions tab -> changelog -> Run
+#     workflow); every run regenerates the entire file, so one run heals all.
+#   - The push below uses GITHUB_TOKEN so it does NOT trigger release.yml.
+#     NEVER substitute a PAT here: that would trigger a (failing) release run
+#     on every changelog commit.
+#   - Requires the "github-actions" app as a bypass actor for required pull
+#     request reviews on the protected main branch.
+
+on:
+  release:
+    types: [published, edited, deleted]
+  workflow_dispatch:
+
+# A retitle + notes edit can emit two `edited` events back to back; keep only
+# the newest run. Safe because each run regenerates the whole file from scratch.
+concurrency:
+  group: changelog
+  cancel-in-progress: true
+
+jobs:
+  changelog:
+    name: "Regenerate CHANGELOG.md from releases"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main   # always regenerate and commit on main, whatever triggered us
+      - uses: rhysd/changelog-from-release/action@v3
+        with:
+          file: CHANGELOG.md
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit_summary_template: 'update CHANGELOG.md for release %s'
+          # -l 2: release titles become "##" headings; -d=false: exclude drafts;
+          # -i: defensively ignore the legacy floating tag if it ever reappears
+          args: -l 2 -d=false -i ^current$
+          header: |
+            # Changelog
+
+            This file is generated automatically from the project's
+            [GitHub releases](https://github.com/UC-Davis-molecular-computing/scadnano-python-package/releases)
+            by [changelog-from-release](https://github.com/rhysd/changelog-from-release).
+            Do not edit it manually; edit the release notes instead.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,34 +1,111 @@
 name: "release"
 
+# On every push to main: tag v{__version__}, create a GitHub release whose body
+# lists commits since the previous release, publish to PyPI, then close issues
+# referenced by closing keywords in those commits.
+#
+# INVARIANT: every push to main is a release. If __version__ in
+# scadnano/scadnano.py was not bumped, this workflow FAILS (red X) on purpose.
+#
+# NEVER substitute a personal access token (PAT) for GITHUB_TOKEN below.
+# Actions taken with GITHUB_TOKEN do not trigger other workflows, and this
+# design depends on that: the issue closes performed here must not trigger
+# reopen-dev-closes.yml, and the release created here must not trigger
+# changelog.yml (at creation time the title is still the "TODO" placeholder).
+
 on:
   push:
     branches:
       - "main"
 
+# Serialize runs so two quick merges to main cannot interleave tag creation or
+# PyPI publishing. Queued, not cancelled: every push must produce (or loudly
+# fail to produce) a release.
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
 jobs:
   release:
-    name: "Release"
-    runs-on: "ubuntu-latest"
+    name: "Create GitHub release"
+    runs-on: ubuntu-latest
     permissions:
-      # Required for trusted publishing to PyPI
-      id-token: write
-      contents: write
-
+      contents: write   # create the vX.Y.Z tag and the release
+    env:
+      GH_TOKEN: ${{ github.token }}   # gh CLI reads this; do NOT replace with a PAT
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      prev_ref: ${{ steps.prev.outputs.prev_ref }}
     steps:
-      # ...
-      - name: "Build & test"
-        run: |
-          echo "done!"
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - uses: actions/checkout@v7
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "current"
-          prerelease: false
-          title: "Development Build [TODO: Replace label and number with version number]"
-          files: |
+          fetch-depth: 0   # full history + all tags, needed for `git log <prev>..HEAD`
+
+      - name: Extract version from scadnano/scadnano.py
+        id: version
+        run: |
+          version=$(sed -nE 's/^__version__ = "([^"]+)".*$/\1/p' scadnano/scadnano.py | head -1)
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error file=scadnano/scadnano.py::could not extract semantic version from the __version__ line (got: '$version')"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Fail loudly if version was not bumped (unless this is a re-run)
+        id: guard
+        run: |
+          version='${{ steps.version.outputs.version }}'
+          if git rev-parse -q --verify "refs/tags/v$version^{commit}" > /dev/null; then
+            tag_commit=$(git rev-parse "refs/tags/v$version^{commit}")
+            if [ "$tag_commit" = "$GITHUB_SHA" ]; then
+              echo "Tag v$version already exists at this exact commit: re-run of a partially failed workflow. Skipping release creation."
+              echo "create_release=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "::error::Tag v$version already exists (at $tag_commit) but this push is $GITHUB_SHA. __version__ in scadnano/scadnano.py was not bumped before merging to main. Bump it on dev and merge dev to main again (see CONTRIBUTING.md); this red X is the intended reminder."
+              exit 1
+            fi
+          else
+            echo "create_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Determine previous release tag
+        id: prev
+        run: |
+          version='${{ steps.version.outputs.version }}'
+          # Newest published, non-draft, non-prerelease release, excluding the
+          # release this run creates (matters on re-runs). Empty if none exists.
+          prev_ref=$(gh release list --exclude-drafts --exclude-pre-releases \
+            --limit 20 --json tagName \
+            --jq "[.[].tagName] | map(select(. != \"v$version\")) | first // empty")
+          echo "prev_ref=$prev_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Create release with commit list since previous release
+        if: steps.guard.outputs.create_release == 'true'
+        run: |
+          version='${{ steps.version.outputs.version }}'
+          prev_ref='${{ steps.prev.outputs.prev_ref }}'
+          if [ -n "$prev_ref" ]; then range="$prev_ref..HEAD"; else range="HEAD"; fi
+          {
+            echo "TODO: describe this release here, then retitle the release to \"v$version\"."
+            echo
+            echo "## Commits"
+            echo
+            git log --format='- %h: %s (%an)' "$range"
+          } > "$RUNNER_TEMP/release-notes.md"
+          gh release create "v$version" \
+            --target "$GITHUB_SHA" \
+            --title "TODO: edit release notes for v$version" \
+            --notes-file "$RUNNER_TEMP/release-notes.md" \
             LICENSE.txt
 
-      # Publish to PyPI using Trusted Publishers
+  publish:
+    name: "Publish to PyPI"
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read    # actions/checkout
+      id-token: write   # PyPI trusted publishing
+    steps:
       - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -42,3 +119,44 @@ jobs:
         run: python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  close-issues:
+    name: "Close issues fixed by this release"
+    needs: [release, publish]   # only mark issues released after PyPI publish succeeds
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read   # actions/checkout
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      VERSION: ${{ needs.release.outputs.version }}
+      PREV_REF: ${{ needs.release.outputs.prev_ref }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Close issues referenced by closing keywords in released commits
+        run: |
+          if [ -n "$PREV_REF" ]; then range="$PREV_REF..HEAD"; else range="HEAD"; fi
+          # Same range as the release notes, so the issues closed here match the
+          # commits listed in the release. GitHub's closing keywords, optional
+          # colon, case-insensitive; issue numbers deduped by sort -un.
+          issues=$(git log --format=%B "$range" \
+            | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?):?[[:space:]]+#[0-9]+' \
+            | grep -oE '[0-9]+' | sort -un) || true
+          if [ -z "$issues" ]; then
+            echo "No closing keywords found in range $range; nothing to do."
+            exit 0
+          fi
+          for n in $issues; do
+            # `gh issue view` fails if #n is a pull request or does not exist; skip those.
+            state=$(gh issue view "$n" --json state --jq .state 2>/dev/null) \
+              || { echo "#$n is not an issue (probably a PR reference); skipping"; continue; }
+            if [ "$state" = "OPEN" ]; then
+              gh issue close "$n" --comment "Released in [v${VERSION}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/v${VERSION}) and published to [PyPI](https://pypi.org/project/scadnano/${VERSION}/)."
+            else
+              echo "#$n already closed (e.g., manually); leaving its state alone"
+            fi
+            # Remove the dev-lifecycle label either way; harmless if absent.
+            gh issue edit "$n" --remove-label "closed in dev" > /dev/null 2>&1 || true
+          done

--- a/.github/workflows/reopen-dev-closes.yml
+++ b/.github/workflows/reopen-dev-closes.yml
@@ -1,0 +1,94 @@
+name: "reopen issues closed by dev commits"
+
+# Once dev is the default branch, closing keywords ("fixes #123") in commits
+# pushed to dev, or in PRs merged into dev, auto-close issues even though the
+# fix is not yet released. This workflow reopens such issues, labels them
+# "closed in dev", and explains. Manual closes are untouched (their ClosedEvent
+# has no Commit/PullRequest closer). Closes performed by release.yml's
+# close-issues job use GITHUB_TOKEN, whose events do not trigger workflows, so
+# released issues are never reopened by this.
+#
+# NEVER substitute a PAT for GITHUB_TOKEN in release.yml: doing so would make
+# this workflow instantly reopen every issue that a release just closed.
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  reopen:
+    name: "Reopen if closed by a commit or PR"
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const issue_number = context.payload.issue.number;
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $number) {
+                    timelineItems(last: 5, itemTypes: [CLOSED_EVENT]) {
+                      nodes {
+                        ... on ClosedEvent {
+                          closer {
+                            __typename
+                            ... on Commit { abbreviatedOid }
+                            ... on PullRequest { number }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`;
+
+            // closer may not be populated the instant the closed event fires;
+            // retry a few times with backoff before concluding "manual close".
+            let closer = null;
+            for (let attempt = 1; attempt <= 3; attempt++) {
+              const result = await github.graphql(query, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: issue_number,
+              });
+              const nodes = result.repository.issue.timelineItems.nodes;
+              closer = nodes.length > 0 ? nodes[nodes.length - 1].closer : null;
+              if (closer !== null) break;
+              if (attempt < 3) await new Promise(r => setTimeout(r, attempt * 5000));
+            }
+
+            // ClosedEvent.closer is a union of Commit | ProjectV2 | PullRequest,
+            // or null for manual closes. Only Commit/PullRequest mean "fixed in dev".
+            if (closer === null || !['Commit', 'PullRequest'].includes(closer.__typename)) {
+              core.info(`#${issue_number}: closed manually (closer: ${closer ? closer.__typename : 'none'}); leaving closed.`);
+              return;
+            }
+
+            const what = closer.__typename === 'Commit'
+              ? `commit ${closer.abbreviatedOid}`
+              : `PR #${closer.number}`;
+            core.info(`#${issue_number}: closed by ${what}; reopening and labeling.`);
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              state: 'open',
+            });
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              labels: ['closed in dev'],
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body: 'Reopening: the fix for this issue was merged to the `dev` branch, '
+                + 'but is not yet released. It will be closed automatically when the fix '
+                + 'is released to `main` and published to PyPI.',
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,11 +70,10 @@ git clone https://github.com/UC-Davis-molecular-computing/scadnano-python-packag
 ```
 
 Changes to the scadnano package should be pushed to the
-[`dev`](https://github.com/UC-Davis-molecular-computing/scadnano-python-package/tree/dev) branch. So switch to the `dev` branch:
-
-```
-git checkout dev
-```
+[`dev`](https://github.com/UC-Davis-molecular-computing/scadnano-python-package/tree/dev) branch,
+which is the default branch, so that is the branch you get when you clone. (The `main` branch
+holds released versions only; see
+[the section on pushing to main](#pushing-to-the-repository-main-branch-and-documenting-changes-done-less-frequently).)
 
 
 
@@ -94,7 +93,7 @@ For any more significant change that is made (e.g., closing an issue, adding a n
 
 1. If there is not already a GitHub issue describing the desired change, make one. Make sure that its title is a self-contained description, and that it describes the change we would like to make to the software. For example, *"problem with importing gridless design"* is a bad title. A better title is *"fix problem where importing gridless design with negative x coordinates throws exception"*.
 
-2. Make a new branch specifically for the issue. Base this branch off of `dev` (**WARNING**: in GitHub desktop, the default is to base it off of `main`, so switch that). The title of the issue (with appropriate hyphenation) is a good name for the branch. (In GitHub Desktop, if you paste the title of the issue, it automatically adds the hyphens.)
+2. Make a new branch specifically for the issue. Since `dev` is the default branch, new branches are based off of `dev` automatically. The title of the issue (with appropriate hyphenation) is a good name for the branch. (In GitHub Desktop, if you paste the title of the issue, it automatically adds the hyphens.)
 
 3. If it is about fixing a bug, *first* add tests to reproduce the bug before working on fixing it. (This is so-called [test-driven development](https://www.google.com/search?q=test-driven+development))
 
@@ -106,13 +105,25 @@ For any more significant change that is made (e.g., closing an issue, adding a n
 
 7. Commit the changes. In the commit message, reference the issue using the phrase "fixes #123" or "closes #123" (see [here](https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords)). Also, in the commit message, describe the issue that was fixed (one easy way is to copy the title of the issue); this message will show up in automatically generated release notes, so this is part of the official documentation of what changed.
 
-8. Create a pull request (PR). **WARNING:** by default, it will want to merge into the `main` branch. Change the destination branch to `dev`.
+8. Create a pull request (PR). Since `dev` is the default branch, the PR targets `dev` automatically.
 
 9. Wait for all checks to complete (see next section), and then merge the changes from the new branch into `dev`. This will typically require someone else to review the code first and possibly request changes.
 
 10. After merging, it will say that the branch you just merged from can be safely deleted. Delete the branch.
 
 11. Locally, remember to switch back to the `dev` branch and pull it. (Although you added those changes locally, they revert back once you switch to your local `dev` branch, which needs to be synced with the remote repo for you to see the changes that were just merged from the now-deleted temporary branch.)
+
+### What happens to the issue when you merge to dev
+
+Because `dev` is the default branch, GitHub automatically closes issue #123 as soon as a commit
+saying "fixes #123" reaches `dev`. But the fix is *not released* at that point: users install from
+PyPI, which is published only from `main`. So a bot immediately reopens the issue, adds the label
+[`closed in dev`](https://github.com/UC-Davis-molecular-computing/scadnano-python-package/labels/closed%20in%20dev),
+and leaves a comment explaining that the fix is merged but not yet released.
+
+This close-then-reopen pair is expected; don't fight it. The issue is closed for good — with a
+comment linking the release and the PyPI package — by the release workflow, after the version
+containing the fix is actually published. Issues you close *by hand* are left alone by the bot.
 
 
 
@@ -128,13 +139,26 @@ Less frequently, pull requests (abbreviated PR) can be made from `dev` to `main`
 
 **WARNING:** Always wait for the checks to complete. This is important to ensure that unit tests pass. 
 
-We have an automated release system (through a GitHub action) that automatically creates release notes when changes are merged into the main branch.
+**WARNING:** This is the one PR whose base branch you must set by hand. `dev` is the default branch,
+so GitHub proposes `dev` as the base; for a release PR, change the base to `main`.
+
+**Every push to `main` is a release.** The release workflow reads `__version__` from
+[scadnano/scadnano.py](scadnano/scadnano.py), creates the tag `v{version}`, creates a GitHub release,
+and publishes to PyPI. So you **must bump `__version__` on `dev` before merging `dev` into `main`**.
+If you forget, the release workflow fails with a red X and an explanatory message, and nothing is
+tagged or published; bump the version on `dev` and merge again to recover. (Practically, this means
+there is no such thing as a casual push to `main` — even a README typo fix rides along with a version
+bump, or waits for the next release.)
+
+We have an automated release system (through a GitHub action) that automatically creates the version
+tag and release notes when changes are merged into the main branch, publishes to PyPI, and closes the
+issues fixed by the release.
 
 Although the GitHub web interface abbreviates long commit messages, the full commit message is included for each commit in a PR.
 
 However, commit descriptions are not shown in the release notes. In GitHub desktop these are two separate fields; on the command line they appear to be indicated by two separate usages of the `-m` flag: https://stackoverflow.com/questions/16122234/how-to-commit-a-change-with-both-message-and-description-from-the-command-li.
 
-So make sure that everything people should see in the automatically generated release notes is included in the commit message. (If not, then more manual editing of the release notes is required.) GitHub lets you [automatically close](https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords) an issue by putting a phrase such as "closes #14". Although the release notes will link to the issue that was closed, they [will not describe it in any other way](https://github.com/marvinpinto/actions/issues/34). So it is important, for the sake of having readable release notes, to describe briefly the issue that was closed in the commit message.
+So make sure that everything people should see in the automatically generated release notes is included in the commit message. (If not, then more manual editing of the release notes is required.) GitHub lets you [automatically close](https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords) an issue by putting a phrase such as "closes #14". The release notes link to the issue that was closed, but do not describe it in any other way. So it is important, for the sake of having readable release notes, to describe briefly the issue that was closed in the commit message.
 
 One simple way to do this is to copy/paste the title of the issue into the commit message. For this reason, issue titles should be stated in terms of what change should happen to handle an issue. For example, instead of the title being *"3D position is improperly calculated from grid position"*, a better issue title is *"calculate 3D position correctly from grid position"*. That way, when the issue is fixed in a commit, that title can simply be copied and pasted as the description of what was done for the commit message. (But you should still add "fixes #<issue_number>" in the commit message, e.g., the full commit message could be *"fixes #101; calculate 3D position correctly from grid position"* .)
 
@@ -148,9 +172,16 @@ So the steps for committing to the main branch are:
 
 1. If necessary, follow the instructions above to merge changes from a temporary branch to the `dev` branch. There will typically be several of these. Despite GitHub's suggestions to keep commit messages short and put longer text in descriptions, because only the commit message is included in the release notes, it's okay to put more detail in the message (but very long stuff should go in the description, or possibly documentation such as the README.md file).
 
-    One of the changes committed should change the version number. We follow [semantic versioning](https://semver.org/). This is a string of the form `"MAJOR.MINOR.PATCH"`, e.g., `"0.9.3"`
+2. Bump the version number on `dev`. This is **required** before every merge into `main`; the release
+   workflow fails if the version was not bumped. We follow [semantic versioning](https://semver.org/):
+   a string of the form `"MAJOR.MINOR.PATCH"`, e.g., `"0.9.3"`. Bump PATCH for bug fixes only, and
+   MINOR for backwards-compatible feature additions.
     - For the web interface repo scadnano, this is located at the top of the file https://github.com/UC-Davis-molecular-computing/scadnano/blob/main/lib/src/constants.dart
-    - For the Python library repo scadnano-python-package, this is located in two places: the bottom of the file https://github.com/UC-Davis-molecular-computing/scadnano-python-package/blob/main/scadnano/_version.py (as `__version__ = "0.9.3"` or something similar) and the near the top of the file https://github.com/UC-Davis-molecular-computing/scadnano-python-package/blob/main/scadnano/scadnano.py (as `__version__ = "0.9.3"` or something similar). This latter one is only there for users who do not install from PyPI, and who simply download the file scadnano.py to put it in a directory with their script).
+    - For the Python library repo scadnano-python-package, there is a single source of truth: the
+      `__version__` line near the top of the file
+      [scadnano/scadnano.py](scadnano/scadnano.py) (as `__version__ = "0.9.3"` or something similar).
+      Keep the trailing `# version line; WARNING: ...` comment intact — `setup.py` finds this line by
+      searching for that comment, and the release workflow reads the same line.
 
     The PATCH version numbers are not always synced between the two repos, but, they should stay synced on MAJOR and MINOR versions. **Note:** right now this isn't quite true since MINOR versions deal with backwards-compatible feature additions, and some features are supported on one but not the other; e.g., modifications can be made in the Python package but not the web interface, and calculating helix rolls/positions from crossovers can be done in the web interface but not the Python package. But post-version-1.0.0, the major and minor versions of the  should be enforced.
 
@@ -158,13 +189,40 @@ So the steps for committing to the main branch are:
 
 4. In the Python repo, ensure that the documentation is generated without errors. First, run `pip install sphinx sphinx_rtd_theme`. This installs [Sphinx](https://www.sphinx-doc.org/en/main/), which is the most well-supported documentation generator for Python. (It's not very friendly, the syntax for things like links in docstrings is awkward, but it's well supported, so we use it.) Then, from within the subfolder `doc`, run the command `make html` (or `make.bat html` on Windows), ensure there are no errors, and inspect the documentation it generates in the folder `_build`.
 
-5. Create a PR to merge changes from dev into main. 
+5. Create a PR to merge changes from dev into main. **Remember to change the base branch to `main`**;
+   it defaults to `dev`.
 
-6. One the PR is reviewed and approved, do the merge.
+6. Once the PR is reviewed and approved, do the merge.
 
-7. Once the PR changes are merged, a release will be automatically created here: https://github.com/UC-Davis-molecular-computing/scadnano/releases or https://github.com/UC-Davis-molecular-computing/scadnano-python-package/releases. It will have a title that is a placerholder, which is a reminder to change its title and tag. Each commit will be documented, with the commit message (but not description) included in the release notes.
+7. The merge triggers the release workflow, which automatically:
+    - creates the tag `v{version}` at the merge commit — **no manual tagging or retagging is needed
+      any more**;
+    - creates a release here: https://github.com/UC-Davis-molecular-computing/scadnano-python-package/releases,
+      titled `TODO: edit release notes for v{version}` (a deliberate placeholder reminding you to do
+      step 8), whose body lists every commit since the previous release, with the commit message (but
+      not description) included;
+    - publishes the package to PyPI;
+    - closes every issue referenced with a closing keyword in those commits, commenting with links to
+      the release and the PyPI package, and removes their `closed in dev` labels.
 
-8. Change *both* the title *and* tag to the version number with a `v` prepended, e.g., `v0.9.3`. It is imperative to change the tag before the next merge into main, or else the release (which defaults to the tag `latest`) will be overwritten.
+8. Edit the release: replace the placeholder title with the version number with a `v` prepended, e.g.,
+   `v0.9.3`, and write a human summary of the release above the auto-generated `## Commits` list.
+   Breaking changes belong at the top here. Saving this edit is also what regenerates `CHANGELOG.md`
+   (see below).
+
+9. Back-merge `main` into `dev`, so that `dev` picks up the release merge commit and the
+   `CHANGELOG.md` commits.
+
+### CHANGELOG.md
+
+[CHANGELOG.md](CHANGELOG.md) is generated automatically from the GitHub releases; **never edit it by
+hand**, since the next run overwrites it. Edit the release notes instead — saving an edit to a release
+regenerates the whole file and commits it to `main`.
+
+Because the file is regenerated from scratch every time, a missed update is never permanent: go to the
+Actions tab, select the `changelog` workflow, and press "Run workflow". This is also the remedy for
+editing a *very old* release (one tagged before this automation existed), which does not trigger the
+workflow on its own.
 
 
 

--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -54,7 +54,7 @@ so the user must take care not to set them.
 # needed to use forward annotations: https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep563
 from __future__ import annotations
 
-__version__ = "0.20.1"  # version line; WARNING: do not remove or change this line or comment
+__version__ = "0.21.0"  # version line; WARNING: do not remove or change this line or comment
 
 import collections
 import dataclasses


### PR DESCRIPTION
Implements the plan for #323. All four parts of the issue are covered.

## What changes

**`.github/workflows/release.yml` (rewritten).** Drops
[`marvinpinto/action-automatic-releases`](https://github.com/marvinpinto/action-automatic-releases),
archived in May 2024, in favor of plain `gh` CLI + `git log` steps — no new
third-party action. On every push to `main` it now:

- reads `__version__` from `scadnano/scadnano.py` and creates the tag
  `v{version}` **at the merge commit**, so the manual retagging ritual (and the
  "retag before the next merge or the release is overwritten" hazard) is gone;
- **fails loudly** if `__version__` was not bumped — nothing is tagged or
  published, and the red X is the reminder. It is safely re-runnable: if the tag
  already points at this exact commit, it skips release creation and proceeds to
  publish;
- creates a release whose body lists every commit since the previous release.
  This is why we generate the list ourselves rather than using GitHub's
  `--generate-notes`: that one is PR-based only and silently drops direct
  commits, of which `dev` has plenty;
- publishes to PyPI (unchanged trusted-publishing steps, moved to their own job
  so it no longer shares `contents: write`);
- closes the issues fixed by the release — but only after the PyPI publish
  succeeds — commenting with links to the release and the package, and removes
  their `closed in dev` labels.

**`.github/workflows/changelog.yml` (new).** Regenerates `CHANGELOG.md` from
*all* GitHub releases on release published/edited/deleted, plus a manual
"Run workflow" button. Regenerating rather than appending means the initial
backfill of all ~61 historical releases is free, later edits to old releases are
picked up, and a missed trigger is cured by one manual run.

**`.github/workflows/reopen-dev-closes.yml` (new).** Once `dev` is the default
branch, `fixes #N` in a dev commit auto-closes the issue even though the fix is
unreleased. This reopens such issues, labels them `closed in dev`, and explains
in a comment. It distinguishes *what* closed the issue via
`ClosedEvent.closer`, whose type is a union of `Commit | ProjectV2 |
PullRequest` — only the first two mean "fixed in dev", so issues you close by
hand, or from a project board, are left alone.

**`CONTRIBUTING.md`** documents the new lifecycle and fixes a stale reference to
`scadnano/_version.py`, which no longer exists (the single source of truth is
the `__version__` line in `scadnano/scadnano.py`). The release steps were also
renumbered — they previously skipped from 1 to 3.

**Version bumped to `0.21.0`.** A MINOR bump rather than PATCH because the range
since v0.20.1 includes a new feature (Autostaple, #317), not only fixes.

## Why this is loop-safe

The design rests on GitHub's rule that anything done with `GITHUB_TOKEN` does
not trigger further workflows. That is what keeps the changelog commit from
triggering a release, and the release's issue-closes from triggering the reopen
bot. Each workflow carries a comment warning that substituting a personal access
token would break all three protections at once.

## Validation

`actionlint` with `shellcheck` integration passes clean on all three workflows.
The closing-keyword regex used by the close-issues job was run against the real
pending commit range and matched exactly the expected issues: #317, #320, #321,
#324.

## Rollout notes

Merging this to `dev` does **not** close #323, because `main` is still the
default branch at merge time; the release workflow closes it at the next
release. The remaining steps — switching the default branch to `dev`, adding
`github-actions` as a bypass actor on `main`'s protection rule, and the release
PR itself — follow after this merge.