### PR TITLE
make the release workflow re-runnable: skip already-published PyPI files

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,6 +12,11 @@ name: "changelog"
 #     events use the workflow file at the tagged commit). Remedy: run this
 #     workflow manually via workflow_dispatch (Actions tab -> changelog -> Run
 #     workflow); every run regenerates the entire file, so one run heals all.
+#   - For the same reason, a release-triggered run uses the `args` and `header`
+#     frozen at THAT tag, not the current ones on dev. So after changing the
+#     formatting below, make a workflow_dispatch run the LAST run: an `edited`
+#     event on an older release would otherwise rewrite CHANGELOG.md in the old
+#     format. (workflow_dispatch always uses the branch you dispatch from.)
 #   - The push below uses GITHUB_TOKEN so it does NOT trigger release.yml.
 #     NEVER substitute a PAT here: that would trigger a (failing) release run
 #     on every changelog commit.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,14 @@ jobs:
         run: python -m build
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Without this, re-running the workflow after a partial failure (say
+          # close-issues died on a transient API error) aborts here, because
+          # PyPI rejects a duplicate file upload. That would contradict the
+          # re-run guard in the release job. `python -m build` produces
+          # deterministic filenames, so a re-run's artifacts match what is
+          # already on PyPI and are correctly skipped.
+          skip-existing: true
 
   close-issues:
     name: "Close issues fixed by this release"


### PR DESCRIPTION
Follow-up to #327, from an adversarial review of the new release automation
(25 candidate findings, 5 survived two independent skeptics each).

## The blocker

`pypa/gh-action-pypi-publish` defaults `skip-existing` to `false`, so PyPI
rejects a duplicate file upload and the step aborts. That made `publish` the
one non-idempotent job in the graph — and it sits upstream of `close-issues`.

This directly contradicts the re-run guard in the `release` job, which
deliberately supports re-running a partially failed release. Concretely: if
`close-issues` died on a transient API error, pressing **Re-run all jobs** (the
prominent button) would correctly skip release creation, then hard-fail in
`publish` on the duplicate, so `close-issues` would still never run. Only the
less obvious "Re-run failed jobs" would have worked.

`python -m build` produces deterministic filenames, so a re-run's artifacts
match what is already on PyPI and are correctly skipped. There is no downside.

## Also

Corrects a comment in `changelog.yml`. A release-triggered run uses the `args`
and `header` frozen **at the tagged commit**, not the current ones on `dev` —
so after changing the formatting, a `workflow_dispatch` run must be the last
run, or an `edited` event on an older release would rewrite `CHANGELOG.md` in
the old format.

`actionlint` with `shellcheck` integration passes clean.