### PR TITLE
fixes #330: test the closed-in-dev automation

### DIFF
--- a/TEST-AUTOMATION-SCRATCH.md
+++ b/TEST-AUTOMATION-SCRATCH.md
@@ -1,0 +1,4 @@
+Temporary scratch file used to test the release/issue automation added in #323.
+
+This exists only so that a commit containing a closing keyword can be merged
+into `dev`. It is deleted immediately after the automation is verified.


### PR DESCRIPTION
Throwaway PR to exercise the reopen + label automation from #323, which has never run. Merging this should auto-close #330, then the bot should reopen it, label it `closed in dev`, and comment. The scratch file is removed in a follow-up PR.