### PR TITLE
bump version to 0.21.1

### DIFF
--- a/scadnano/scadnano.py
+++ b/scadnano/scadnano.py
@@ -54,7 +54,7 @@ so the user must take care not to set them.
 # needed to use forward annotations: https://docs.python.org/3/whatsnew/3.7.html#whatsnew37-pep563
 from __future__ import annotations
 
-__version__ = "0.21.0"  # version line; WARNING: do not remove or change this line or comment
+__version__ = "0.21.1"  # version line; WARNING: do not remove or change this line or comment
 
 import collections
 import dataclasses


### PR DESCRIPTION
Version bump ahead of a release whose purpose is to deploy `retarget-pr-to-dev.yml` to `main`. `pull_request_target` reads its workflow file from the default branch, so that workflow cannot run until it lands there.

No functional change to the package.