### PR TITLE
stop closing issues from the release workflow; GitHub already does it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,8 +134,8 @@ jobs:
           # already on PyPI and are correctly skipped.
           skip-existing: true
 
-  close-issues:
-    name: "Close issues fixed by this release"
+  annotate-issues:
+    name: "Annotate and clean up issues fixed by this release"
     needs: [release, publish]   # only mark issues released after PyPI publish succeeds
     runs-on: ubuntu-latest
     permissions:
@@ -149,12 +149,17 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Close issues referenced by closing keywords in released commits
+      - name: Note the release on, and unlabel, issues fixed by it
         run: |
+          # This job does NOT close issues. main is the default branch, so GitHub
+          # itself acts on the closing keywords the moment this push lands,
+          # seconds before this runs. What GitHub does not do is say WHICH
+          # release shipped the fix, or remove the "closed in dev" label that
+          # label-fixed-in-dev.yml applied while the fix was unreleased.
           if [ -n "$PREV_REF" ]; then range="$PREV_REF..HEAD"; else range="HEAD"; fi
-          # Same range as the release notes, so the issues closed here match the
-          # commits listed in the release. GitHub's closing keywords, optional
-          # colon, case-insensitive; issue numbers deduped by sort -un.
+          # Same range as the release notes, so the issues annotated here match
+          # the commits listed in the release. GitHub's closing keywords,
+          # optional colon, case-insensitive; numbers deduped by sort -un.
           issues=$(git log --format=%B "$range" \
             | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?):?[[:space:]]+#[0-9]+' \
             | grep -oE '[0-9]+' | sort -un) || true
@@ -164,27 +169,28 @@ jobs:
           fi
           released_note="Released in [v${VERSION}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/v${VERSION}) and published to [PyPI](https://pypi.org/project/scadnano/${VERSION}/)."
           for n in $issues; do
-            # `gh issue view` fails if #n is a pull request or does not exist; skip those.
-            state=$(gh issue view "$n" --json state --jq .state 2>/dev/null) \
-              || { echo "#$n is not an issue (probably a PR reference); skipping"; continue; }
-            if [ "$state" = "OPEN" ]; then
-              gh issue close "$n" --comment "$released_note"
-            else
-              # Already closed -- most often because main is the default branch,
-              # so GitHub acted on the closing keyword the moment this push
-              # landed, seconds before this job ran. Comment anyway, so the issue
-              # still records which release shipped the fix; do not touch state,
-              # in case it was closed by hand for an unrelated reason.
-              # Skip if such a note is already there, so re-running this workflow
-              # does not post duplicate comments.
-              if gh issue view "$n" --json comments --jq '.comments[].body' 2>/dev/null \
-                   | grep -qF "releases/tag/v${VERSION}"; then
-                echo "#$n already closed and already notes v${VERSION}; skipping"
-              else
-                echo "#$n already closed; commenting without changing its state"
-                gh issue comment "$n" --body "$released_note" > /dev/null
-              fi
+            # A number matched here can be a pull request, or can simply not
+            # exist -- a commit message may mention "fixes #123" as an example of
+            # the syntax rather than as a real reference. The issues API returns
+            # a .pull_request field only for pull requests; commenting on one
+            # needs pull-requests: write, which this job deliberately lacks.
+            meta=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${n}" \
+                     --jq '[(.pull_request != null), .state] | @tsv' 2>/dev/null) \
+              || { echo "#$n does not exist; skipping"; continue; }
+            is_pr=$(printf '%s' "$meta" | cut -f1)
+            if [ "$is_pr" = "true" ]; then
+              echo "#$n is a pull request, not an issue; skipping"
+              continue
             fi
-            # Remove the dev-lifecycle label either way; harmless if absent.
+            # Record which release shipped the fix, unless that is already noted
+            # (so re-running this workflow does not post duplicate comments).
+            if gh issue view "$n" --json comments --jq '.comments[].body' 2>/dev/null \
+                 | grep -qF "releases/tag/v${VERSION}"; then
+              echo "#$n already notes v${VERSION}; not commenting again"
+            else
+              echo "#$n: noting that v${VERSION} shipped the fix"
+              gh issue comment "$n" --body "$released_note" > /dev/null
+            fi
+            # Remove the dev-lifecycle label; harmless if absent.
             gh issue edit "$n" --remove-label "closed in dev" > /dev/null 2>&1 || true
           done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,9 +155,10 @@ GitHub's own "fixes #123" auto-closing only acts on commits reaching the **defau
 is `main`. That is the main reason `main` is kept as the default: it means merging a fix to `dev`
 does not prematurely tell users the issue is done.
 
-The issue is closed for good, with a comment linking the release and the PyPI package, by the
-release workflow once the fix is actually published — which also removes the `closed in dev` label.
-Issues you close by hand are not touched by any of this.
+The issue is closed for good once the fix is actually released. GitHub does that itself: the
+release merges those same commits into `main`, the default branch, where its "fixes #123" handling
+applies. The release workflow then adds a comment linking the release and the PyPI package, and
+removes the `closed in dev` label. Issues you close by hand are not touched by any of this.
 
 
 
@@ -238,8 +239,9 @@ So the steps for committing to the main branch are:
       step 8), whose body lists every commit since the previous release, with the commit message (but
       not description) included;
     - publishes the package to PyPI;
-    - closes every issue referenced with a closing keyword in those commits, commenting with links to
-      the release and the PyPI package, and removes their `closed in dev` labels.
+    - comments on every issue referenced with a closing keyword in those commits, with links to the
+      release and the PyPI package, and removes their `closed in dev` labels. (The issues are
+      *closed* by GitHub itself, since those commits reach `main`, the default branch.)
 
 8. Edit the release: replace the placeholder title with the version number with a `v` prepended, e.g.,
    `v0.9.3`, and write a human summary of the release above the auto-generated `## Commits` list.


### PR DESCRIPTION
Fixes the failure in the v0.21.1 release run, and removes work the release
workflow no longer needs to do.

## Why the closing was redundant

With `main` as the default branch, GitHub acts on `fixes #123` itself when the
release merges those commits into `main` — seconds before this job runs. Closing
them again here achieved nothing.

## Why it actually broke

The job tried to comment on **#123, which is a pull request**. Commenting on a PR
requires `pull-requests: write`, which this job deliberately does not have:

```
GraphQL: Resource not accessible by integration (addComment)
```

#123 was in scope only because a commit message mentioned `"fixes #123"` as an
*example of the syntax*, not as a real reference. The keyword regex cannot tell
the difference — a known limitation, which here escalated from harmless to a red
X on a release.

## What the job does now

Renamed `close-issues` → `annotate-issues`, doing only what GitHub does not:

- comments which release shipped the fix, with links to the release and PyPI
  (skipped if already noted, so re-runs don't duplicate);
- removes the `closed in dev` label applied by `label-fixed-in-dev.yml`.

Numbers that are pull requests, or that don't exist, are now skipped
*explicitly* via the issues API's `.pull_request` field, rather than by hoping a
`gh` command happens to fail — which is what went wrong, since `gh issue view`
succeeds on a PR number.

**Adding** the `closed in dev` label on pushes to `dev` is unchanged.

## Validation

`actionlint` + `shellcheck` clean. The new skip logic was dry-run against the
live API for all three cases: #123 (a PR) → skipped; #317 (a real issue) →
proceeds; #999999 (nonexistent) → skipped.