### PR TITLE
remove the release workflow's issue-annotation job

### DIFF
--- a/.github/workflows/label-fixed-in-dev.yml
+++ b/.github/workflows/label-fixed-in-dev.yml
@@ -6,8 +6,12 @@ name: "label issues fixed in dev"
 # leaves them OPEN.
 #
 # GitHub's own auto-close only acts on the default branch (main), so nothing
-# closes these issues here. They are closed for real by release.yml's
-# close-issues job once the fix is published, which also removes this label.
+# closes these issues here. They are closed by GitHub itself once the release
+# carries the same commits to main.
+#
+# The label is never removed, so it accumulates on closed issues. That is fine:
+# `is:open label:"closed in dev"` finds exactly the fixes that are merged but not
+# yet released, because released ones are closed.
 #
 # This replaces an earlier "reopen issues closed by dev commits" workflow, which
 # was needed only while dev was the default branch: back then GitHub closed such
@@ -49,8 +53,8 @@ jobs:
             range="$BEFORE..$AFTER"
           fi
 
-          # Same closing keywords, and the same matching, as release.yml's
-          # close-issues job, so the two agree on which issues a change fixes.
+          # GitHub's closing keywords, optional colon, case-insensitive, matching
+          # what GitHub itself acts on when these commits later reach main.
           # shellcheck disable=SC2086
           issues=$(git log --format=%B $range \
             | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?):?[[:space:]]+#[0-9]+' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,19 @@
 name: "release"
 
 # On every push to main: tag v{__version__}, create a GitHub release whose body
-# lists commits since the previous release, publish to PyPI, then close issues
-# referenced by closing keywords in those commits.
+# lists commits since the previous release, and publish to PyPI.
+#
+# Issues are not touched here. main is the default branch, so GitHub itself
+# closes any issue referenced by a closing keyword in the commits this push
+# brings to main, and records the closing commit on the issue.
 #
 # INVARIANT: every push to main is a release. If __version__ in
 # scadnano/scadnano.py was not bumped, this workflow FAILS (red X) on purpose.
 #
 # NEVER substitute a personal access token (PAT) for GITHUB_TOKEN below.
-# Actions taken with GITHUB_TOKEN do not trigger other workflows, and this
-# design depends on that: the issue closes performed here must not trigger
-# reopen-dev-closes.yml, and the release created here must not trigger
-# changelog.yml (at creation time the title is still the "TODO" placeholder).
+# Actions taken with GITHUB_TOKEN do not trigger other workflows, and the
+# release created here depends on that: it must not trigger changelog.yml,
+# because at creation time its title is still the "TODO" placeholder.
 
 on:
   push:
@@ -126,71 +128,17 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          # Without this, re-running the workflow after a partial failure (say
-          # close-issues died on a transient API error) aborts here, because
-          # PyPI rejects a duplicate file upload. That would contradict the
-          # re-run guard in the release job. `python -m build` produces
-          # deterministic filenames, so a re-run's artifacts match what is
-          # already on PyPI and are correctly skipped.
+          # Without this, re-running the workflow after a partial failure aborts
+          # here, because PyPI rejects a duplicate file upload. That would
+          # contradict the re-run guard in the release job. `python -m build`
+          # produces deterministic filenames, so a re-run's artifacts match what
+          # is already on PyPI and are correctly skipped.
           skip-existing: true
 
-  annotate-issues:
-    name: "Annotate and clean up issues fixed by this release"
-    needs: [release, publish]   # only mark issues released after PyPI publish succeeds
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read   # actions/checkout
-      issues: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-      VERSION: ${{ needs.release.outputs.version }}
-      PREV_REF: ${{ needs.release.outputs.prev_ref }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Note the release on, and unlabel, issues fixed by it
-        run: |
-          # This job does NOT close issues. main is the default branch, so GitHub
-          # itself acts on the closing keywords the moment this push lands,
-          # seconds before this runs. What GitHub does not do is say WHICH
-          # release shipped the fix, or remove the "closed in dev" label that
-          # label-fixed-in-dev.yml applied while the fix was unreleased.
-          if [ -n "$PREV_REF" ]; then range="$PREV_REF..HEAD"; else range="HEAD"; fi
-          # Same range as the release notes, so the issues annotated here match
-          # the commits listed in the release. GitHub's closing keywords,
-          # optional colon, case-insensitive; numbers deduped by sort -un.
-          issues=$(git log --format=%B "$range" \
-            | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?):?[[:space:]]+#[0-9]+' \
-            | grep -oE '[0-9]+' | sort -un) || true
-          if [ -z "$issues" ]; then
-            echo "No closing keywords found in range $range; nothing to do."
-            exit 0
-          fi
-          released_note="Released in [v${VERSION}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/v${VERSION}) and published to [PyPI](https://pypi.org/project/scadnano/${VERSION}/)."
-          for n in $issues; do
-            # A number matched here can be a pull request, or can simply not
-            # exist -- a commit message may mention "fixes #123" as an example of
-            # the syntax rather than as a real reference. The issues API returns
-            # a .pull_request field only for pull requests; commenting on one
-            # needs pull-requests: write, which this job deliberately lacks.
-            meta=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${n}" \
-                     --jq '[(.pull_request != null), .state] | @tsv' 2>/dev/null) \
-              || { echo "#$n does not exist; skipping"; continue; }
-            is_pr=$(printf '%s' "$meta" | cut -f1)
-            if [ "$is_pr" = "true" ]; then
-              echo "#$n is a pull request, not an issue; skipping"
-              continue
-            fi
-            # Record which release shipped the fix, unless that is already noted
-            # (so re-running this workflow does not post duplicate comments).
-            if gh issue view "$n" --json comments --jq '.comments[].body' 2>/dev/null \
-                 | grep -qF "releases/tag/v${VERSION}"; then
-              echo "#$n already notes v${VERSION}; not commenting again"
-            else
-              echo "#$n: noting that v${VERSION} shipped the fix"
-              gh issue comment "$n" --body "$released_note" > /dev/null
-            fi
-            # Remove the dev-lifecycle label; harmless if absent.
-            gh issue edit "$n" --remove-label "closed in dev" > /dev/null 2>&1 || true
-          done
+          # Nothing acts on issues after the release. main is the default branch,
+          # so GitHub itself closes any issue referenced by a closing keyword in
+          # the commits this push brings to main, and records the closing commit
+          # on the issue. The "closed in dev" label added by label-fixed-in-dev.yml
+          # is left in place; `is:open label:"closed in dev"` still finds exactly
+          # the fixes that are merged but not yet released, because released ones
+          # are closed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,8 +157,12 @@ does not prematurely tell users the issue is done.
 
 The issue is closed for good once the fix is actually released. GitHub does that itself: the
 release merges those same commits into `main`, the default branch, where its "fixes #123" handling
-applies. The release workflow then adds a comment linking the release and the PyPI package, and
-removes the `closed in dev` label. Issues you close by hand are not touched by any of this.
+applies, and it records the closing commit on the issue. Issues you close by hand are unaffected.
+
+The `closed in dev` label is not removed at that point, so to find fixes that are merged but not yet
+released, search for
+[`is:open label:"closed in dev"`](https://github.com/UC-Davis-molecular-computing/scadnano-python-package/issues?q=is%3Aopen+label%3A%22closed+in+dev%22)
+— once released, the issue is closed, so it drops out of that list.
 
 
 
@@ -238,10 +242,10 @@ So the steps for committing to the main branch are:
       titled `TODO: edit release notes for v{version}` (a deliberate placeholder reminding you to do
       step 8), whose body lists every commit since the previous release, with the commit message (but
       not description) included;
-    - publishes the package to PyPI;
-    - comments on every issue referenced with a closing keyword in those commits, with links to the
-      release and the PyPI package, and removes their `closed in dev` labels. (The issues are
-      *closed* by GitHub itself, since those commits reach `main`, the default branch.)
+    - publishes the package to PyPI.
+
+    Issues referenced with a closing keyword in those commits are closed by GitHub itself, since the
+    commits reach `main`, the default branch; the workflow does not touch issues at all.
 
 8. Edit the release: replace the placeholder title with the version number with a `v` prepended, e.g.,
    `v0.9.3`, and write a human summary of the release above the auto-generated `## Commits` list.


### PR DESCRIPTION
Removes the last remaining issue-touching job from `release.yml`, per the
observation that GitHub already does the part that matters.

`main` is the default branch, so GitHub closes any issue referenced by a closing
keyword in the commits a release brings to `main`, and records the closing commit
on the issue — which is enough to trace back to the release.

That left the job doing two things not worth an action: posting a comment naming
the release, and removing the `closed in dev` label. Both are now gone.

Dropping them also removes a whole class of failure. The job had to decide, for
every number its regex matched, whether it was an issue, a pull request, or
nonexistent — and it got that wrong in the v0.21.1 release, where it tried to
comment on a pull request (matched from an illustrative `"fixes #123"` in a
commit message) and failed with `Resource not accessible by integration`.

`release.yml` is now two jobs: create the release, publish to PyPI.

## The label

It is never removed now, so it accumulates on closed issues. That is fine —
[`is:open label:"closed in dev"`](https://github.com/UC-Davis-molecular-computing/scadnano-python-package/issues?q=is%3Aopen+label%3A%22closed+in+dev%22)
still finds exactly the fixes that are merged but not yet released, because
released ones are closed. CONTRIBUTING.md documents this.

**Adding** the label on pushes to `dev` is unchanged.